### PR TITLE
feat: Inject global.SENTRY_RELEASE.id into source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ const config = {
 
 #### Options
 
-* `release [optional]` - unique name of a release, can be either a `string` or a `function` which will expose you a compilation hash as it's first argument, which is 20-char long string, unique for a given codebase, defaults to `sentry-cli releases propose-version` command which should always return the correct version
+* `release [optional]` - unique name of a release, must be a `string`, should uniquely identify your release, defaults to `sentry-cli releases propose-version` command which should always return the correct version
 * `include [required]` - `string` or `array`, one or more paths that Sentry CLI should scan recursively for sources. It will upload all `.map` files and match associated `.js` files
 * `ignoreFile [optional]` - `string`, path to a file containing list of files/directories to ignore. Can point to `.gitignore` or anything with same format
 * `ignore [optional]` - `string` or `array`, one or more paths to ignore during upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or `ignore` are present, defaults to `['node_modules']`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">= 6.0.0"
   },
   "dependencies": {
-    "@sentry/cli": "^1.28.0"
+    "@sentry/cli": "^1.28.1"
   },
   "devDependencies": {
     "codecov": "^3.0.0",

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,11 +1,13 @@
 const newMock = jest.fn(() => Promise.resolve());
 const uploadSourceMapsMock = jest.fn(() => Promise.resolve());
 const finalizeMock = jest.fn(() => Promise.resolve());
+const proposeVersionMock = jest.fn(() => Promise.resolve());
 const SentryCliMock = jest.fn(configFile => ({
   releases: {
     new: newMock,
     uploadSourceMaps: uploadSourceMapsMock,
-    finalize: finalizeMock
+    finalize: finalizeMock,
+    proposeVersion: proposeVersionMock
   }
 }));
 
@@ -74,7 +76,7 @@ describe('.apply', () => {
 
   test('should create exactly one instance of SentryCli with `configFile` if passed', () => {
     const sentryCliPlugin = new SentryCliPlugin({
-      release: 42,
+      release: '42',
       include: 'src',
       configFile: './some/file'
     });
@@ -125,9 +127,7 @@ describe('.apply callback function', () => {
   test('should evaluate `release` option with compilation hash if its passed as a function', done => {
     expect.assertions(2);
     const sentryCliPlugin = new SentryCliPlugin({
-      release(hash) {
-        return hash + 'Evaluated';
-      },
+      release: 'someHashEvaluated',
       include: 'src'
     });
     sentryCliPlugin.apply(compiler);

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -144,7 +144,7 @@ describe('.apply callback function', () => {
 
     beforeEach(() => {
       sentryCliPlugin = new SentryCliPlugin({
-        release: 42,
+        release: '42',
         include: 'src'
       });
     });
@@ -154,14 +154,14 @@ describe('.apply callback function', () => {
       sentryCliPlugin.apply(compiler);
 
       setImmediate(() => {
-        expect(newMock).toBeCalledWith(42);
-        expect(uploadSourceMapsMock).toBeCalledWith(42, {
+        expect(newMock).toBeCalledWith('42');
+        expect(uploadSourceMapsMock).toBeCalledWith('42', {
           ignore: undefined,
-          release: 42,
+          release: '42',
           include: ['src'],
           rewrite: true
         });
-        expect(finalizeMock).toBeCalledWith(42);
+        expect(finalizeMock).toBeCalledWith('42');
         expect(compilationDoneCallback).toBeCalled();
         done();
       });

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,16 @@ function SentryCliPlugin(options = {}) {
 }
 
 function injectEntry(originalEntry, newEntry) {
-  console.log(originalEntry);
   if (Array.isArray(originalEntry)) {
-    originalEntry.unshift(newEntry);
-    return originalEntry;
+    return [newEntry].concat(originalEntry);
+  }
+
+  if (originalEntry !== null && typeof originalEntry === 'object') {
+    var nextEntries = {};
+    Object.keys(originalEntry).forEach(function(key) {
+      nextEntries[key] = injectEntry(originalEntry[key], newEntry);
+    });
+    return nextEntries;
   }
 
   if (typeof originalEntry === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -65,10 +65,7 @@ function replaceRelease(compilation, version) {
     chunk.files.forEach(function(filename) {
       var source = compilation.assets[filename]
         .source()
-        .replace(
-          'global.SENTRY_RELEASE.id="";',
-          'global.SENTRY_RELEASE.id="' + version + '";'
-        );
+        .replace('SENTRY_RELEASE.id=""', 'SENTRY_RELEASE.id="' + version + '"');
       replaceInFile(compilation.assets[filename].existsAt, source);
     });
   });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 var SentryCli = require('@sentry/cli');
+var path = require('path');
+var fs = require('fs');
 
 function SentryCliPlugin(options = {}) {
   // By default we want that rewrite is true
@@ -10,11 +12,75 @@ function SentryCliPlugin(options = {}) {
     options.ignore && (Array.isArray(options.ignore) ? options.ignore : [options.ignore]);
 }
 
+function injectEntry(originalEntry, newEntry) {
+  console.log(originalEntry);
+  if (Array.isArray(originalEntry)) {
+    originalEntry.unshift(newEntry);
+    return originalEntry;
+  }
+
+  if (typeof originalEntry === 'string') {
+    return [newEntry, originalEntry];
+  }
+
+  return newEntry;
+}
+
+function injectRelease(compiler, version) {
+  if (typeof compiler.options === 'undefined') {
+    // Gatekeeper because we are not running in webpack env
+    // probably just tests
+    return;
+  }
+  compiler.options.entry = injectEntry(
+    compiler.options.entry,
+    path.join(__dirname, 'sentry-webpack.module.js')
+  );
+  compiler.options.module = {};
+  compiler.options.module.rules = [];
+  compiler.options.module.rules.push({
+    test: /sentry-webpack\.module\.js$/,
+    use: [
+      {
+        loader: path.resolve(__dirname, 'sentry.loader.js'),
+        query: {version}
+      }
+    ]
+  });
+}
+
+function replaceInFile(file, source) {
+  fs.writeFile(file, source, 'utf8', function(err) {
+    if (err) return console.log(err);
+  });
+}
+
+function replaceRelease(compilation, version) {
+  if (typeof compilation.chunks === 'undefined') {
+    // Gatekeeper because we are not running in webpack env
+    // probably just tests
+    return;
+  }
+  compilation.chunks.forEach(function(chunk) {
+    chunk.files.forEach(function(filename) {
+      var source = compilation.assets[filename]
+        .source()
+        .replace(
+          'global.SENTRY_RELEASE.id="";',
+          'global.SENTRY_RELEASE.id="' + version + '";'
+        );
+      replaceInFile(compilation.assets[filename].existsAt, source);
+    });
+  });
+}
+
 SentryCliPlugin.prototype.apply = function(compiler) {
   var sentryCli = new SentryCli(this.options.configFile);
   var release = this.options.release;
   var include = this.options.include;
   var options = this.options;
+
+  injectRelease(compiler, 'global.SENTRY_RELEASE={};\nglobal.SENTRY_RELEASE.id="";');
 
   compiler.plugin('after-emit', function(compilation, cb) {
     function handleError(message, cb) {
@@ -35,7 +101,8 @@ SentryCliPlugin.prototype.apply = function(compiler) {
 
     return versionPromise
       .then(function(proposedVersion) {
-        options.release = proposedVersion;
+        options.release = (proposedVersion + '').trim();
+        replaceRelease(compilation, options.release);
         return sentryCli.releases.new(options.release);
       })
       .then(function() {

--- a/src/sentry-webpack.module.js
+++ b/src/sentry-webpack.module.js
@@ -1,0 +1,1 @@
+// This will be replaced

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,3 +1,10 @@
-module.exports = function() {
-  return this.query.version;
+module.exports = function(content, map, meta) {
+  var versionPromise = this.query.versionPromise;
+  var callback = this.async();
+  versionPromise.then(function(version) {
+    var version = (version + '').trim();
+    var sentryRelease =
+      'global.SENTRY_RELEASE={};\nglobal.SENTRY_RELEASE.id="' + version + '";';
+    callback(null, sentryRelease, map, meta);
+  });
 };

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,0 +1,3 @@
+module.exports = function() {
+  return this.query.version;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,9 +10,9 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@sentry/cli@^1.27.0":
-  version "1.28.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.28.0.tgz#ef0bb4fd06d4af918f22e4e253e330bd7855cb1d"
+"@sentry/cli@^1.28.1":
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.28.1.tgz#42feaa7f5db056dad1ebfbb80af5c01c1f46b82d"
   dependencies:
     progress "2.0.0"
 


### PR DESCRIPTION

This is a breaking change, we no longer support compilation hash for now since this would conflict with code injection.

Basically what we do is, we inject 
```javascript
global.SENTRY_RELEASE={};
global.SENTRY_RELEASE.id="#MYHASH#";
```
into the webpack bundle.

<details>
    <summary>Old comment</summary>
So I am not really happy with how this works right now.

I wasn't able to inject code during compilation into the source, how it's working now is:

Before compilation I add a fake module to the source containing
```javascript
global.SENTRY_RELEASE={};
global.SENTRY_RELEASE.id="";
```

After compilation I iterate over all chunks, and replace the corresponding code on the file system so the result in the compiled file is:

```javascript
global.SENTRY_RELEASE={};
global.SENTRY_RELEASE.id="#MYHASH#";
```

I will gladly take advice on how to make it better.
</details>


