### PR TITLE
Fix formatting issue in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const config = {
 * `ignore [optional]` - `string` or `array`, one or more paths to ignore during upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or `ignore` are present, defaults to `['node_modules']`
 * `configFile [optional]` - `string`, path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files. By default, the config file is looked for upwards from the current path and defaults from `~/.sentryclirc` are always loaded
 * `ext [optional]` - `string`, adds an additional file extension to be considered. By default the following file extensions are processed: js, map, jsbundle and bundle.
-* `urlPrefix [optional]` - `string`, this sets an URL prefix in front of all files. This defaults to ~/ but you might want to set this to the full URL. This is also useful if your files are stored in a sub folder. eg: --url-prefix '~/static/js'
+* `urlPrefix [optional]` - `string`, this sets an URL prefix in front of all files. This defaults to `~/` but you might want to set this to the full URL. This is also useful if your files are stored in a sub folder. eg: `--url-prefix '~/static/js'`
 * `validate [optional]` - `boolean`, this attempts sourcemap validation before upload when rewriting is not enabled. It will spot a variety of issues with source maps and cancel the upload if any are found. This is not the default as this can cause false positives.
 * `stripPrefix | stripCommonPrefix [optional]` - `string`, when paired with `--rewrite` this will chop-off a prefix from uploaded files. For instance you can use this to remove a path that is build machine specific.
 * `sourceMapReference [optional]` - `boolean`, this prevents the automatic detection of sourcemap references.


### PR DESCRIPTION
Most of the description for `urlPrefix` looked like ~strike-through text~.