### PR TITLE
ref: Handle old module.loaders syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,18 +35,28 @@ function injectRelease(compiler, versionPromise) {
   if (typeof changedCompiler.options.module === 'undefined') {
     changedCompiler.options.module = {};
   }
-  if (typeof changedCompiler.options.module.rules === 'undefined') {
-    changedCompiler.options.module.rules = [];
+
+  // Handle old `module.loaders` syntax
+  if (typeof changedCompiler.options.module.loaders !== 'undefined') {
+    changedCompiler.options.module.loaders.push({
+      test: /sentry-webpack\.module\.js$/,
+      loader: path.resolve(__dirname, 'sentry.loader.js'),
+      options: { versionPromise },
+    });
+  } else {
+    if (typeof changedCompiler.options.module.rules === 'undefined') {
+      changedCompiler.options.module.rules = [];
+    }
+    changedCompiler.options.module.rules.push({
+      test: /sentry-webpack\.module\.js$/,
+      use: [
+        {
+          loader: path.resolve(__dirname, 'sentry.loader.js'),
+          options: { versionPromise },
+        },
+      ],
+    });
   }
-  changedCompiler.options.module.rules.push({
-    test: /sentry-webpack\.module\.js$/,
-    use: [
-      {
-        loader: path.resolve(__dirname, 'sentry.loader.js'),
-        query: { versionPromise },
-      },
-    ],
-  });
 }
 
 class SentryCliPlugin {


### PR DESCRIPTION
Fixes: https://github.com/getsentry/sentry-webpack-plugin/issues/28 and https://github.com/getsentry/sentry-webpack-plugin/issues/27

It's not deprecated and only "recommended" by official Webpack docs, so we should probably still support it - https://webpack.js.org/guides/migrating/#module-loaders-is-now-module-rules