### PR TITLE
add support for dynamic entry 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,11 @@ function injectEntry(originalEntry, newEntry) {
     return [newEntry, originalEntry];
   }
 
+  if (typeof originalEntry === 'function') {
+    return () =>
+      Promise.resolve(originalEntry()).then(entry => injectEntry(entry, newEntry));
+  }
+
   return newEntry;
 }
 


### PR DESCRIPTION
webpack allows to configure the `entry` dynamic https://webpack.js.org/configuration/entry-context/#dynamic-entry.  

I added support for injecting the sentry entry also in dynamic entries, otherwise the plugin would output corrupt bundles.