### PR TITLE
use webpack v4 new Tapable plugins hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,11 +16,11 @@
       }
     },
     "@sentry/cli": {
-      "version": "1.29.1",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.29.1.tgz",
-      "integrity": "sha1-K287te+kmgahifxJyqh7Qqe4eNg=",
+      "version": "1.30.3",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-1.30.3.tgz",
+      "integrity": "sha1-AtD3eBwe5eG+WkMSoyX76LGzcjE=",
       "requires": {
-        "https-proxy-agent": "2.1.1",
+        "https-proxy-agent": "2.2.0",
         "node-fetch": "1.7.3",
         "progress": "2.0.0",
         "proxy-from-env": "1.0.0"
@@ -2714,9 +2714,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
-      "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
+      "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
       "requires": {
         "agent-base": "4.2.0",
         "debug": "3.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,14 @@ class SentryCliPlugin {
       },
     };
   }
+  attachAfterEmitHook(compiler, callback) {
+    // Backwards compatible version of: compiler.plugin.afterEmit.tapAsync()
+    if (compiler.hooks) {
+      compiler.hooks.afterEmit.tapAsync('SentryCliPlugin', callback);
+    } else {
+      compiler.plugin('after-emit', callback);
+    }
+  }
 
   apply(compiler) {
     const sentryCli = this.getSentryCli();
@@ -103,7 +111,7 @@ class SentryCliPlugin {
 
     injectRelease(compiler, versionPromise);
 
-    compiler.plugin('after-emit', (compilation, cb) => {
+    this.attachAfterEmitHook(compiler, (compilation, cb) => {
       function handleError(message, errorCb) {
         compilation.errors.push(`Sentry CLI Plugin: ${message}`);
         return errorCb();


### PR DESCRIPTION
Webpack v4 uses new API for plugins to apply hooks. In this PR I used that new API if it is available. 