### PR TITLE
feat: Add an option to skip entries

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "trailingComma": "es5",
   "singleQuote": true,
-  "printWidth": 90
+  "proseWrap": "always",
+  "printWidth": 80
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_install:
 
 matrix:
   include:
+    - env: NAME="lint"
+      script:
+        - yarn lint
+
     - env: NAME="test"
       script:
         - yarn test
@@ -30,7 +34,7 @@ matrix:
         - yarn test
         - yarn run codecov
 
-    - env: NAME="integration test"
+    - env: NAME="integration"
       node_js: "6"
       script:
         - yarn test:integration

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 [![deps dev](https://david-dm.org/getsentry/sentry-webpack-plugin/dev-status.svg)](https://david-dm.org/getsentry/sentry-webpack-plugin?type=dev&view=list)
 [![deps peer](https://david-dm.org/getsentry/sentry-webpack-plugin/peer-status.svg)](https://david-dm.org/getsentry/sentry-webpack-plugin?type=peer&view=list)
 
-A webpack plugin acting as an interface to [Sentry CLI](https://docs.sentry.io/learn/cli/).
+A webpack plugin acting as an interface to
+[Sentry CLI](https://docs.sentry.io/learn/cli/).
 
 ### Installation
 
@@ -34,7 +35,8 @@ $ yarn add @sentry/webpack-plugin --dev
 
 ### CLI Configuration
 
-You can use either `.sentryclirc` file or ENV variables described here https://docs.sentry.io/learn/cli/configuration/
+You can use either `.sentryclirc` file or ENV variables described here
+https://docs.sentry.io/learn/cli/configuration/
 
 ### Usage
 
@@ -47,9 +49,9 @@ const config = {
       include: '.',
       ignoreFile: '.sentrycliignore',
       ignore: ['node_modules', 'webpack.config.js'],
-      configFile: 'sentry.properties'
-    })
-  ]
+      configFile: 'sentry.properties',
+    }),
+  ],
 };
 ```
 
@@ -57,18 +59,46 @@ Also, check the [example](example) directory.
 
 #### Options
 
-* `release [optional]` - unique name of a release, must be a `string`, should uniquely identify your release, defaults to `sentry-cli releases propose-version` command which should always return the correct version
-* `include [required]` - `string` or `array`, one or more paths that Sentry CLI should scan recursively for sources. It will upload all `.map` files and match associated `.js` files
-* `ignoreFile [optional]` - `string`, path to a file containing list of files/directories to ignore. Can point to `.gitignore` or anything with same format
-* `ignore [optional]` - `string` or `array`, one or more paths to ignore during upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or `ignore` are present, defaults to `['node_modules']`
-* `configFile [optional]` - `string`, path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files. By default, the config file is looked for upwards from the current path and defaults from `~/.sentryclirc` are always loaded
-* `ext [optional]` - `string`, adds an additional file extension to be considered. By default the following file extensions are processed: js, map, jsbundle and bundle.
-* `urlPrefix [optional]` - `string`, this sets an URL prefix in front of all files. This defaults to `~/` but you might want to set this to the full URL. This is also useful if your files are stored in a sub folder. eg: `url-prefix '~/static/js'`
-* `validate [optional]` - `boolean`, this attempts sourcemap validation before upload when rewriting is not enabled. It will spot a variety of issues with source maps and cancel the upload if any are found. This is not the default as this can cause false positives.
-* `stripPrefix [optional]` - `array`, when paired with `rewrite` this will chop-off a prefix from uploaded files. For instance you can use this to remove a path that is build machine specific.
-* `stripCommonPrefix [optional]` - `boolean`, when paired with `rewrite` this will add `~` to the `stripPrefix` array.
-* `sourceMapReference [optional]` - `boolean`, this prevents the automatic detection of sourcemap references.
-* `rewrite [optional]` - `boolean`, enables rewriting of matching sourcemaps so that indexed maps are flattened and missing sources are inlined if possible., defaults to `true`
-* `dryRun [optional]` - `boolean`, attempts a dry run (useful for dev environments) 
+* `release [optional]` - unique name of a release, must be a `string`, should
+  uniquely identify your release, defaults to
+  `sentry-cli releases propose-version` command which should always return the
+  correct version
+* `include [required]` - `string` or `array`, one or more paths that Sentry CLI
+  should scan recursively for sources. It will upload all `.map` files and match
+  associated `.js` files
+* `ignoreFile [optional]` - `string`, path to a file containing list of
+  files/directories to ignore. Can point to `.gitignore` or anything with same
+  format
+* `ignore [optional]` - `string` or `array`, one or more paths to ignore during
+  upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or
+  `ignore` are present, defaults to `['node_modules']`
+* `configFile [optional]` - `string`, path to Sentry CLI config properties, as
+  described in https://docs.sentry.io/learn/cli/configuration/#properties-files.
+  By default, the config file is looked for upwards from the current path and
+  defaults from `~/.sentryclirc` are always loaded
+* `ext [optional]` - `string`, adds an additional file extension to be
+  considered. By default the following file extensions are processed: js, map,
+  jsbundle and bundle.
+* `urlPrefix [optional]` - `string`, this sets an URL prefix in front of all
+  files. This defaults to `~/` but you might want to set this to the full URL.
+  This is also useful if your files are stored in a sub folder. eg:
+  `url-prefix '~/static/js'`
+* `validate [optional]` - `boolean`, this attempts sourcemap validation before
+  upload when rewriting is not enabled. It will spot a variety of issues with
+  source maps and cancel the upload if any are found. This is not the default as
+  this can cause false positives.
+* `stripPrefix [optional]` - `array`, when paired with `rewrite` this will
+  chop-off a prefix from uploaded files. For instance you can use this to remove
+  a path that is build machine specific.
+* `stripCommonPrefix [optional]` - `boolean`, when paired with `rewrite` this
+  will add `~` to the `stripPrefix` array.
+* `sourceMapReference [optional]` - `boolean`, this prevents the automatic
+  detection of sourcemap references.
+* `rewrite [optional]` - `boolean`, enables rewriting of matching sourcemaps so
+  that indexed maps are flattened and missing sources are inlined if possible.,
+  defaults to `true`
+* `dryRun [optional]` - `boolean`, attempts a dry run (useful for dev
+  environments)
 
-You can find more information about these options in our official docs: https://docs.sentry.io/learn/cli/releases/#upload-source-maps
+You can find more information about these options in our official docs:
+https://docs.sentry.io/learn/cli/releases/#upload-source-maps

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Also, check the [example](example) directory.
 * `include [required]` - `string` or `array`, one or more paths that Sentry CLI
   should scan recursively for sources. It will upload all `.map` files and match
   associated `.js` files
-* `entries [optional]` - `array` or `RegExp` or `function`, a filter for entry
-  points that should be processed. By default, the release will be injected into
-  all entry points.
+* `entries [optional]` - `array` or `RegExp` or `function(key: string): bool`, a
+  filter for entry points that should be processed. By default, the release will
+  be injected into all entry points.
 * `ignoreFile [optional]` - `string`, path to a file containing list of
   files/directories to ignore. Can point to `.gitignore` or anything with same
   format

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Also, check the [example](example) directory.
 * `include [required]` - `string` or `array`, one or more paths that Sentry CLI
   should scan recursively for sources. It will upload all `.map` files and match
   associated `.js` files
+* `entries [optional]` - `array` or `RegExp` or `function`, a filter for entry
+  points that should be processed. By default, the release will be injected into
+  all entry points.
 * `ignoreFile [optional]` - `string`, path to a file containing list of
   files/directories to ignore. Can point to `.gitignore` or anything with same
   format

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  collectCoverage: true,
+  testEnvironment: 'node',
+  testPathIgnorePatterns: ['example'],
+};

--- a/package.json
+++ b/package.json
@@ -33,12 +33,7 @@
     "test:eslint": "eslint src",
     "test": "jest",
     "test:integration": "cd example && yarn && yarn test",
+    "test:watch": "jest --watch --notify",
     "codecov": "codecov"
-  },
-  "jest": {
-    "collectCoverage": true,
-    "testPathIgnorePatterns": [
-      "example"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,11 +26,17 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-import": "^2.10.0",
     "jest": "^22.4.3",
-    "prettier": "^1.11.1"
+    "npm-run-all": "^4.1.2",
+    "prettier": "^1.11.1",
+    "prettier-check": "^2.0.0"
   },
   "scripts": {
+    "lint": "run-s lint:prettier lint:eslint",
+    "lint:prettier": "prettier-check 'src/**/*.js'",
+    "lint:eslint": "eslint src",
+    "fix": "run-s fix:eslint fix:prettier",
+    "fix:prettier": "prettier --write 'src/**/*.js'",
     "fix:eslint": "eslint --fix src",
-    "test:eslint": "eslint src",
     "test": "jest",
     "test:integration": "cd example && yarn && yarn test",
     "test:watch": "jest --watch --notify",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   },
   "devDependencies": {
     "codecov": "^3.0.0",
-    "eslint": "^4.15.0",
+    "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-config-prettier": "^2.9.0",
-    "eslint-plugin-import": "^2.8.0",
-    "jest": "^22.0.6",
-    "prettier": "^1.10.2"
+    "eslint-plugin-import": "^2.10.0",
+    "jest": "^22.4.3",
+    "prettier": "^1.11.1"
   },
   "scripts": {
     "fix:eslint": "eslint --fix src",

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -138,7 +138,10 @@ describe('afterEmitHook', () => {
     compiler = { plugin: jest.fn() };
     sentryCliPlugin.apply(compiler);
 
-    expect(compiler.plugin).toHaveBeenCalledWith('after-emit', expect.any(Function));
+    expect(compiler.plugin).toHaveBeenCalledWith(
+      'after-emit',
+      expect.any(Function)
+    );
   });
 
   test('errors without `include` option', done => {
@@ -157,7 +160,10 @@ describe('afterEmitHook', () => {
   test('creates a release on Sentry', done => {
     expect.assertions(4);
 
-    const sentryCliPlugin = new SentryCliPlugin({ include: 'src', release: 42 });
+    const sentryCliPlugin = new SentryCliPlugin({
+      include: 'src',
+      release: 42,
+    });
     sentryCliPlugin.apply(compiler);
 
     setImmediate(() => {
@@ -180,7 +186,10 @@ describe('afterEmitHook', () => {
       Promise.reject(new Error('Pickle Rick'))
     );
 
-    const sentryCliPlugin = new SentryCliPlugin({ include: 'src', release: 42 });
+    const sentryCliPlugin = new SentryCliPlugin({
+      include: 'src',
+      release: 42,
+    });
     sentryCliPlugin.apply(compiler);
 
     setImmediate(() => {
@@ -353,7 +362,10 @@ describe('entry point overrides', () => {
   test('filters entry points by name', done => {
     expect.assertions(1);
 
-    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    compiler.options.entry = {
+      main: './src/index.js',
+      admin: './src/admin.js',
+    };
     sentryCliPlugin.options.entries = ['admin'];
     sentryCliPlugin.apply(compiler);
 
@@ -368,7 +380,10 @@ describe('entry point overrides', () => {
   test('filters entry points by RegExp', done => {
     expect.assertions(1);
 
-    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    compiler.options.entry = {
+      main: './src/index.js',
+      admin: './src/admin.js',
+    };
     sentryCliPlugin.options.entries = /^ad/;
     sentryCliPlugin.apply(compiler);
 
@@ -383,7 +398,10 @@ describe('entry point overrides', () => {
   test('filters entry points by function', done => {
     expect.assertions(1);
 
-    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    compiler.options.entry = {
+      main: './src/index.js',
+      admin: './src/admin.js',
+    };
     sentryCliPlugin.options.entries = key => key == 'admin';
     sentryCliPlugin.apply(compiler);
 
@@ -396,7 +414,10 @@ describe('entry point overrides', () => {
   });
 
   test('throws for an invalid `entries` option', () => {
-    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    compiler.options.entry = {
+      main: './src/index.js',
+      admin: './src/admin.js',
+    };
     sentryCliPlugin.options.entries = 42;
     expect(() => sentryCliPlugin.apply(compiler)).toThrowError(/entries/);
   });

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -40,7 +40,7 @@ describe('constructor', () => {
     });
   });
 
-  test('does not override options with defaults', () => {
+  test('uses declared options over defaults', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       rewrite: false,
     });
@@ -78,7 +78,7 @@ describe('constructor', () => {
 });
 
 describe('CLI configuration', () => {
-  test('uses a mock SentryCLI in `dryRun` mode', () => {
+  test('does not create a SentryCLI instance in `dryRun` mode', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       dryRun: true,
     });
@@ -131,7 +131,7 @@ describe('afterEmitHook', () => {
     );
   });
 
-  test('calls `compiler.plugin("after-emit")` legacy Webpack 2', () => {
+  test('calls `compiler.plugin("after-emit")` legacy Webpack <= 3', () => {
     const sentryCliPlugin = new SentryCliPlugin();
 
     // Simulate Webpack <= 2

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -1,5 +1,8 @@
 /*eslint-disable*/
 
+const SENTRY_LOADER_RE = /sentry\.loader\.js$/;
+const SENTRY_MODULE_RE = /sentry-webpack\.module\.js$/;
+
 const mockCli = {
   releases: {
     new: jest.fn(() => Promise.resolve()),
@@ -17,8 +20,8 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-describe('new SentryCliPlugin(options)', () => {
-  test('when no options provided should use defaults', () => {
+describe('constructor', () => {
+  test('uses defaults without options', () => {
     const sentryCliPlugin = new SentryCliPlugin();
 
     expect(sentryCliPlugin.options).toEqual({
@@ -26,7 +29,7 @@ describe('new SentryCliPlugin(options)', () => {
     });
   });
 
-  test('provided options should be merged with defaults', () => {
+  test('merges defaults with options', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       foo: 42,
     });
@@ -37,7 +40,17 @@ describe('new SentryCliPlugin(options)', () => {
     });
   });
 
-  test('`include` and `ignore` options should be wrapped in arrays when passed as strings', () => {
+  test('does not override options with defaults', () => {
+    const sentryCliPlugin = new SentryCliPlugin({
+      rewrite: false,
+    });
+
+    expect(sentryCliPlugin.options).toEqual({
+      rewrite: false,
+    });
+  });
+
+  test('sanitizes array options `include` and `ignore`', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: 'foo',
       ignore: 'bar',
@@ -50,7 +63,7 @@ describe('new SentryCliPlugin(options)', () => {
     });
   });
 
-  test('`include` and `ignore` options should not be wrapped in arrays again when already passed as ones', () => {
+  test('keeps array options `include` and `ignore`', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: ['foo'],
       ignore: ['bar'],
@@ -64,78 +77,36 @@ describe('new SentryCliPlugin(options)', () => {
   });
 });
 
-describe('.apply', () => {
-  let compiler;
-
-  beforeEach(() => {
-    compiler = {
-      hooks: {
-        afterEmit: {
-          tapAsync: jest.fn(),
-        },
-      },
-    };
-  });
-
-  test('should create exactly one instance of SentryCli with `configFile` if passed', () => {
+describe('CLI configuration', () => {
+  test('uses a mock SentryCLI in `dryRun` mode', () => {
     const sentryCliPlugin = new SentryCliPlugin({
-      release: '42',
-      include: 'src',
-      configFile: './some/file',
+      dryRun: true,
     });
-    sentryCliPlugin.apply(compiler);
 
-    expect(SentryCliMock).toBeCalledWith('./some/file');
+    expect(SentryCliMock).not.toHaveBeenCalled();
+  });
+
+  test('passes the configuration file to CLI', () => {
+    const sentryCliPlugin = new SentryCliPlugin({
+      configFile: 'some/sentry.properties',
+    });
+
+    expect(SentryCliMock).toHaveBeenCalledWith('some/sentry.properties');
+  });
+
+  test('only creates a single CLI instance', () => {
+    const sentryCliPlugin = new SentryCliPlugin({});
+    sentryCliPlugin.apply({ hooks: { afterEmit: { tapAsync: jest.fn() } } });
     expect(SentryCliMock.mock.instances.length).toBe(1);
-  });
-
-  test('should call `compiler.hooks.afterEmit.tapAsync()` with callback function', () => {
-    const sentryCliPlugin = new SentryCliPlugin();
-    sentryCliPlugin.apply(compiler);
-
-    expect(compiler.hooks.afterEmit.tapAsync).toHaveBeenCalledWith(
-      'SentryCliPlugin',
-      expect.any(Function)
-    );
-  });
-
-  describe('Webpack <= 3', () => {
-    let _compiler;
-
-    beforeAll(() => {
-      _compiler = compiler;
-    });
-
-    beforeEach(() => {
-      compiler = {
-        plugin: jest.fn(),
-      };
-    });
-
-    afterAll(() => {
-      compiler = _compiler;
-    });
-
-    test('should call `compiler.plugin()` with `after-emit` and callback function', () => {
-      const sentryCliPlugin = new SentryCliPlugin();
-      sentryCliPlugin.apply(compiler);
-
-      expect(compiler.plugin).toHaveBeenCalledWith('after-emit', expect.any(Function));
-    });
   });
 });
 
-describe('.apply callback function', () => {
+describe('afterEmitHook', () => {
+  let compiler;
   let compilation;
   let compilationDoneCallback;
-  let compiler;
 
   beforeEach(() => {
-    compilation = {
-      errors: [],
-      hash: 'someHash',
-    };
-    compilationDoneCallback = jest.fn();
     compiler = {
       hooks: {
         afterEmit: {
@@ -145,78 +116,288 @@ describe('.apply callback function', () => {
         },
       },
     };
+
+    compilation = { errors: [], hash: 'someHash' };
+    compilationDoneCallback = jest.fn();
   });
 
-  test('should bail-out when no `include` option provided', done => {
-    const sentryCliPlugin = new SentryCliPlugin({
-      release: 42,
-    });
+  test('calls `hooks.afterEmit.tapAsync()`', () => {
+    const sentryCliPlugin = new SentryCliPlugin();
+    sentryCliPlugin.apply(compiler);
+
+    expect(compiler.hooks.afterEmit.tapAsync).toHaveBeenCalledWith(
+      'SentryCliPlugin',
+      expect.any(Function)
+    );
+  });
+
+  test('calls `compiler.plugin("after-emit")` legacy Webpack 2', () => {
+    const sentryCliPlugin = new SentryCliPlugin();
+
+    // Simulate Webpack <= 2
+    compiler = { plugin: jest.fn() };
+    sentryCliPlugin.apply(compiler);
+
+    expect(compiler.plugin).toHaveBeenCalledWith('after-emit', expect.any(Function));
+  });
+
+  test('errors without `include` option', done => {
+    const sentryCliPlugin = new SentryCliPlugin({ release: 42 });
     sentryCliPlugin.apply(compiler);
 
     setImmediate(() => {
+      expect(compilationDoneCallback).toBeCalled();
       expect(compilation.errors).toEqual([
         'Sentry CLI Plugin: `include` option is required',
       ]);
-      expect(compilationDoneCallback).toBeCalled();
       done();
     });
   });
 
-  test('should evaluate `release` option with compilation hash if its passed as a function', done => {
-    expect.assertions(2);
-    const sentryCliPlugin = new SentryCliPlugin({
-      release: 'someHashEvaluated',
-      include: 'src',
-    });
+  test('creates a release on Sentry', done => {
+    expect.assertions(4);
+
+    const sentryCliPlugin = new SentryCliPlugin({ include: 'src', release: 42 });
     sentryCliPlugin.apply(compiler);
 
     setImmediate(() => {
+      expect(mockCli.releases.new).toBeCalledWith('42');
+      expect(mockCli.releases.uploadSourceMaps).toBeCalledWith('42', {
+        ignore: undefined,
+        release: 42,
+        include: ['src'],
+        rewrite: true,
+      });
+      expect(mockCli.releases.finalize).toBeCalledWith('42');
       expect(compilationDoneCallback).toBeCalled();
-      expect(sentryCliPlugin.options.release).toBe('someHashEvaluated');
       done();
     });
   });
 
-  describe('SentryCli calls flow', () => {
-    let sentryCliPlugin;
+  test('handles errors during releasing', done => {
+    expect.assertions(2);
+    mockCli.releases.new.mockImplementationOnce(() =>
+      Promise.reject(new Error('Pickle Rick'))
+    );
 
-    beforeEach(() => {
-      sentryCliPlugin = new SentryCliPlugin({
-        release: '42',
-        include: 'src',
-      });
+    const sentryCliPlugin = new SentryCliPlugin({ include: 'src', release: 42 });
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compilation.errors).toEqual(['Sentry CLI Plugin: Pickle Rick']);
+      expect(compilationDoneCallback).toBeCalled();
+      done();
     });
+  });
+});
 
-    test('should call all required SentryCli methods in sequence', done => {
-      expect.assertions(4);
-      sentryCliPlugin.apply(compiler);
+describe('module rule overrides', () => {
+  let compiler;
+  let sentryCliPlugin;
 
-      setImmediate(() => {
-        expect(mockCli.releases.new).toBeCalledWith('42');
-        expect(mockCli.releases.uploadSourceMaps).toBeCalledWith('42', {
-          ignore: undefined,
-          release: '42',
-          include: ['src'],
-          rewrite: true,
-        });
-        expect(mockCli.releases.finalize).toBeCalledWith('42');
-        expect(compilationDoneCallback).toBeCalled();
+  beforeEach(() => {
+    sentryCliPlugin = new SentryCliPlugin({ release: '42', include: 'src' });
+    compiler = {
+      hooks: { afterEmit: { tapAsync: jest.fn() } },
+      options: { module: {} },
+    };
+  });
+
+  test('injects a `rule` for our mock module', done => {
+    expect.assertions(1);
+
+    compiler.options.module.rules = [];
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.module.rules[0]).toEqual({
+        test: /sentry-webpack\.module\.js$/,
+        use: [
+          {
+            loader: expect.stringMatching(SENTRY_LOADER_RE),
+            options: { releasePromise: expect.any(Promise) },
+          },
+        ],
+      });
+      done();
+    });
+  });
+
+  test('injects a `loader` for our mock module', done => {
+    expect.assertions(1);
+
+    compiler.options.module.loaders = [];
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.module.loaders[0]).toEqual({
+        test: /sentry-webpack\.module\.js$/,
+        loader: expect.stringMatching(SENTRY_LOADER_RE),
+        options: { releasePromise: expect.any(Promise) },
+      });
+      done();
+    });
+  });
+
+  test('defaults to `rules` when nothing is specified', done => {
+    expect.assertions(1);
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.module.rules).toBeInstanceOf(Array);
+      done();
+    });
+  });
+
+  test('creates the `module` option if missing', done => {
+    expect.assertions(1);
+
+    delete compiler.options.module;
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.module).not.toBeUndefined();
+      done();
+    });
+  });
+});
+
+describe('entry point overrides', () => {
+  let compiler;
+  let sentryCliPlugin;
+
+  beforeEach(() => {
+    sentryCliPlugin = new SentryCliPlugin({ release: '42', include: 'src' });
+    compiler = {
+      hooks: { afterEmit: { tapAsync: jest.fn() } },
+      options: { module: { rules: [] } },
+    };
+  });
+
+  test('creates an entry if none is specified', done => {
+    expect.assertions(1);
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toMatch(SENTRY_MODULE_RE);
+      done();
+    });
+  });
+
+  test('injects into a single entry', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = './src/index.js';
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual([
+        expect.stringMatching(SENTRY_MODULE_RE),
+        './src/index.js',
+      ]);
+      done();
+    });
+  });
+
+  test('injects into an array entry', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = ['./src/preload.js', './src/index.js'];
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual([
+        expect.stringMatching(SENTRY_MODULE_RE),
+        './src/preload.js',
+        './src/index.js',
+      ]);
+      done();
+    });
+  });
+
+  test('injects into multiple entries', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = {
+      main: './src/index.js',
+      admin: './src/admin.js',
+    };
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual({
+        main: [expect.stringMatching(SENTRY_MODULE_RE), './src/index.js'],
+        admin: [expect.stringMatching(SENTRY_MODULE_RE), './src/admin.js'],
+      });
+      done();
+    });
+  });
+
+  test('injects into entries specified by a function', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = () => Promise.resolve('./src/index.js');
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      compiler.options.entry().then(entry => {
+        expect(entry).toEqual([
+          expect.stringMatching(SENTRY_MODULE_RE),
+          './src/index.js',
+        ]);
         done();
       });
     });
+  });
 
-    test('when failed, should handle the error', done => {
-      expect.assertions(2);
-      mockCli.releases.new.mockImplementationOnce(() =>
-        Promise.reject(new Error('Pickle Rick'))
-      );
-      sentryCliPlugin.apply(compiler);
+  test('filters entry points by name', done => {
+    expect.assertions(1);
 
-      setImmediate(() => {
-        expect(compilation.errors).toEqual(['Sentry CLI Plugin: Pickle Rick']);
-        expect(compilationDoneCallback).toBeCalled();
-        done();
+    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    sentryCliPlugin.options.entries = ['admin'];
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual({
+        admin: [expect.stringMatching(SENTRY_MODULE_RE), './src/admin.js'],
       });
+      done();
     });
+  });
+
+  test('filters entry points by RegExp', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    sentryCliPlugin.options.entries = /^ad/;
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual({
+        admin: [expect.stringMatching(SENTRY_MODULE_RE), './src/admin.js'],
+      });
+      done();
+    });
+  });
+
+  test('filters entry points by function', done => {
+    expect.assertions(1);
+
+    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    sentryCliPlugin.options.entries = key => key == 'admin';
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compiler.options.entry).toEqual({
+        admin: [expect.stringMatching(SENTRY_MODULE_RE), './src/admin.js'],
+      });
+      done();
+    });
+  });
+
+  test('throws for an invalid `entries` option', () => {
+    compiler.options.entry = { main: './src/index.js', admin: './src/admin.js' };
+    sentryCliPlugin.options.entries = 42;
+    expect(() => sentryCliPlugin.apply(compiler)).toThrowError(/entries/);
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,9 @@ class SentryCliPlugin {
       return entries.indexOf(key) >= 0;
     }
 
-    throw new Error('Invalid `entries` option: Must be an array, RegExp or function');
+    throw new Error(
+      'Invalid `entries` option: Must be an array, RegExp or function'
+    );
   }
 
   /** Injects the release string into the given entry point. */
@@ -131,7 +133,9 @@ class SentryCliPlugin {
 
     if (typeof originalEntry === 'function') {
       return () =>
-        Promise.resolve(originalEntry()).then(entry => this.injectEntry(entry, newEntry));
+        Promise.resolve(originalEntry()).then(entry =>
+          this.injectEntry(entry, newEntry)
+        );
     }
 
     return newEntry;

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const SentryCli = require('@sentry/cli');
 const path = require('path');
 
 const SENTRY_LOADER = path.resolve(__dirname, 'sentry.loader.js');
-const SENTRY_MODULE = path.join(__dirname, 'sentry-webpack.module.js');
+const SENTRY_MODULE = path.resolve(__dirname, 'sentry-webpack.module.js');
 
 /**
  * Helper function that ensures an object key is defined. This mutates target!
@@ -90,7 +90,7 @@ class SentryCliPlugin {
   /** Checks if the given named entry point should be handled. */
   checkEntry(key) {
     const { entries } = this.options;
-    if (!entries) {
+    if (entries == null) {
       return true;
     }
 
@@ -103,7 +103,7 @@ class SentryCliPlugin {
     }
 
     if (Array.isArray(entries)) {
-      return entries.indexOf(key) >= 0;
+      return entries.includes(key);
     }
 
     throw new Error(

--- a/src/index.js
+++ b/src/index.js
@@ -1,135 +1,184 @@
 const SentryCli = require('@sentry/cli');
 const path = require('path');
 
-function injectEntry(originalEntry, newEntry) {
-  if (Array.isArray(originalEntry)) {
-    return [newEntry].concat(originalEntry);
-  }
+const SENTRY_MODULE = path.join(__dirname, 'sentry-webpack.module.js');
+const DRY_RUN_CLI = {
+  releases: {
+    proposeVersion: () => Promise.resolve('1.0.0-dev'),
+    new: () => Promise.resolve(),
+    uploadSourceMaps: () => Promise.resolve(),
+    finalize: () => Promise.resolve(),
+  },
+};
 
-  if (originalEntry !== null && typeof originalEntry === 'object') {
-    const nextEntries = {};
-    Object.keys(originalEntry).forEach(key => {
-      nextEntries[key] = injectEntry(originalEntry[key], newEntry);
-    });
-    return nextEntries;
-  }
-
-  if (typeof originalEntry === 'string') {
-    return [newEntry, originalEntry];
-  }
-
-  if (typeof originalEntry === 'function') {
-    return () =>
-      Promise.resolve(originalEntry()).then(entry => injectEntry(entry, newEntry));
-  }
-
-  return newEntry;
+/**
+ * Helper function that ensures an object key is defined. This mutates target!
+ *
+ * @param {object} target The target object
+ * @param {string} key The object key
+ * @param {function} factory A function that creates the new element
+ * @returns {any} The existing or created element.
+ */
+function ensure(target, key, factory) {
+  // eslint-disable-next-line no-param-reassign
+  target[key] = typeof target[key] !== 'undefined' ? target[key] : factory();
+  return target[key];
 }
 
-function injectRelease(compiler, versionPromise) {
-  if (typeof compiler.options === 'undefined') {
-    // Gatekeeper because we are not running in webpack env
-    // probably just tests
-    return;
-  }
-  const changedCompiler = compiler;
-  changedCompiler.options.entry = injectEntry(
-    changedCompiler.options.entry,
-    path.join(__dirname, 'sentry-webpack.module.js')
-  );
-  if (typeof changedCompiler.options.module === 'undefined') {
-    changedCompiler.options.module = {};
-  }
+/**
+ * Ensures that the passed value is in an array or an array itself.
+ *
+ * @param {any} value Either an array or a value that should be wrapped
+ * @returns {array} The array
+ */
+function toArray(value) {
+  return !value || Array.isArray(value) ? value : [value];
+}
 
-  // Handle old `module.loaders` syntax
-  if (typeof changedCompiler.options.module.loaders !== 'undefined') {
-    changedCompiler.options.module.loaders.push({
-      test: /sentry-webpack\.module\.js$/,
-      loader: path.resolve(__dirname, 'sentry.loader.js'),
-      options: { versionPromise },
-    });
+/** Backwards compatible version of `compiler.plugin.afterEmit.tapAsync()`. */
+function attachAfterEmitHook(compiler, callback) {
+  if (compiler.hooks) {
+    compiler.hooks.afterEmit.tapAsync('SentryCliPlugin', callback);
   } else {
-    if (typeof changedCompiler.options.module.rules === 'undefined') {
-      changedCompiler.options.module.rules = [];
-    }
-    changedCompiler.options.module.rules.push({
-      test: /sentry-webpack\.module\.js$/,
-      use: [
-        {
-          loader: path.resolve(__dirname, 'sentry.loader.js'),
-          options: { versionPromise },
-        },
-      ],
-    });
+    compiler.plugin('after-emit', callback);
   }
+}
+
+/** Convenience function to add a webpack compilation error. */
+function addCompilationError(compilation, message) {
+  compilation.errors.push(`Sentry CLI Plugin: ${message}`);
 }
 
 class SentryCliPlugin {
   constructor(options = {}) {
     // By default we want that rewrite is true
     this.options = Object.assign({ rewrite: true }, options);
-    this.options.include =
-      options.include &&
-      (Array.isArray(options.include) ? options.include : [options.include]);
-    this.options.ignore =
-      options.ignore &&
-      (Array.isArray(options.ignore) ? options.ignore : [options.ignore]);
+    this.options.include = toArray(options.include);
+    this.options.ignore = toArray(options.ignore);
 
-    this.dryRun = this.options.dryRun === true;
+    this.cli = this.getSentryCli();
+    this.release = this.getReleasePromise();
   }
 
+  /** Returns whether this plugin is in dryRun mode. */
+  isDryRun() {
+    return this.options.dryRun === true;
+  }
+
+  /** Creates a new Sentry CLI instance. */
   getSentryCli() {
-    if (!this.dryRun) {
-      return new SentryCli(this.options.configFile);
+    return this.isDryRun() ? DRY_RUN_CLI : new SentryCli(this.options.configFile);
+  }
+
+  /**
+   * Returns a Promise that will solve to the configured release.
+   *
+   * If no release is specified, it uses Sentry CLI to propose a version. The
+   * release string is always trimmed.
+   */
+  getReleasePromise() {
+    return (this.options.release
+      ? Promise.resolve(this.options.release)
+      : this.cli.releases.proposeVersion()
+    ).then(version => `${version}`.trim());
+  }
+
+  /** Injects the release string into the given entry point. */
+  injectEntry(originalEntry, newEntry) {
+    if (Array.isArray(originalEntry)) {
+      return [newEntry].concat(originalEntry);
     }
-    return {
-      releases: {
-        proposeVersion: () => Promise.resolve('1.0.0-dev'),
-        new: () => Promise.resolve(),
-        uploadSourceMaps: () => Promise.resolve(),
-        finalize: () => Promise.resolve(),
-      },
+
+    if (originalEntry !== null && typeof originalEntry === 'object') {
+      const nextEntries = {};
+      Object.keys(originalEntry).forEach(key => {
+        nextEntries[key] = this.injectEntry(originalEntry[key], newEntry);
+      });
+      return nextEntries;
+    }
+
+    if (typeof originalEntry === 'string') {
+      return [newEntry, originalEntry];
+    }
+
+    if (typeof originalEntry === 'function') {
+      return () =>
+        Promise.resolve(originalEntry()).then(entry => this.injectEntry(entry, newEntry));
+    }
+
+    return newEntry;
+  }
+
+  /** Webpack 2: Adds a new loader for the release module. */
+  injectLoader(loaders) {
+    const loader = {
+      test: /sentry-webpack\.module\.js$/,
+      loader: path.resolve(__dirname, 'sentry.loader.js'),
+      options: { releasePromise: this.release },
     };
+
+    return loaders.concat([loader]);
   }
-  attachAfterEmitHook(compiler, callback) {
-    // Backwards compatible version of: compiler.plugin.afterEmit.tapAsync()
-    if (compiler.hooks) {
-      compiler.hooks.afterEmit.tapAsync('SentryCliPlugin', callback);
+
+  /** Webpack 3+: Injects a new rule for the release module. */
+  injectRule(rules) {
+    const rule = {
+      test: /sentry-webpack\.module\.js$/,
+      use: [
+        {
+          loader: path.resolve(__dirname, 'sentry.loader.js'),
+          options: { releasePromise: this.release },
+        },
+      ],
+    };
+
+    return rules.concat([rule]);
+  }
+
+  /** Injects the release entry points and rules into the given options. */
+  injectRelease(compilerOptions) {
+    const options = compilerOptions;
+    if (typeof options === 'undefined') {
+      // Gatekeeper because we are not running in webpack env, probably just tests
+      return;
+    }
+
+    options.entry = this.injectEntry(options.entry, SENTRY_MODULE);
+
+    const mod = ensure(options, 'module', Object);
+    if (module.loaders) {
+      // Handle old `module.loaders` syntax
+      mod.loaders = this.injectLoader(mod.loaders);
     } else {
-      compiler.plugin('after-emit', callback);
+      mod.rules = this.injectRule(mod.rules || []);
     }
   }
 
-  apply(compiler) {
-    const sentryCli = this.getSentryCli();
-    const { release, include } = this.options;
+  /** Creates and finalizes a release on Sentry. */
+  finalizeRelease(compilation) {
+    const { include } = this.options;
 
-    let versionPromise = Promise.resolve(release);
-    if (typeof release === 'undefined') {
-      versionPromise = sentryCli.releases.proposeVersion();
+    if (!include) {
+      addCompilationError(compilation, '`include` option is required');
+      return Promise.resolve();
     }
 
-    injectRelease(compiler, versionPromise);
+    let release;
+    return this.release
+      .then(proposedVersion => {
+        release = proposedVersion;
+        return this.cli.releases.new(release);
+      })
+      .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
+      .then(() => this.cli.releases.finalize(release))
+      .catch(err => addCompilationError(compilation, err.message));
+  }
 
-    this.attachAfterEmitHook(compiler, (compilation, cb) => {
-      function handleError(message, errorCb) {
-        compilation.errors.push(`Sentry CLI Plugin: ${message}`);
-        return errorCb();
-      }
-
-      if (!include) return handleError('`include` option is required', cb);
-
-      return versionPromise
-        .then(proposedVersion => {
-          this.options.release = `${proposedVersion}`.trim();
-          return sentryCli.releases.new(this.options.release);
-        })
-        .then(() =>
-          sentryCli.releases.uploadSourceMaps(this.options.release, this.options)
-        )
-        .then(() => sentryCli.releases.finalize(this.options.release))
-        .then(() => cb())
-        .catch(err => handleError(err.message, cb));
+  /** Webpack lifecycle hook to update compiler options. */
+  apply(compiler) {
+    this.injectRelease(compiler.options);
+    attachAfterEmitHook(compiler, (compilation, cb) => {
+      this.finalizeRelease(compilation).then(() => cb());
     });
   }
 }

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,8 +1,8 @@
 module.exports = function sentryLoader(content, map, meta) {
-  const { versionPromise } = this.query;
+  const { releasePromise } = this.query;
   const callback = this.async();
-  versionPromise.then(version => {
-    const newVersion = `${version}`.trim();
+  releasePromise.then(version => {
+    const newVersion = version;
     const sentryRelease = `global.SENTRY_RELEASE={};\nglobal.SENTRY_RELEASE.id="${newVersion}";`;
     callback(null, sentryRelease, map, meta);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,9 +47,13 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^5.0.0, acorn@^5.1.2, acorn@^5.2.1:
+acorn@^5.0.0, acorn@^5.1.2:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+acorn@^5.5.0:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
 
 agent-base@^4.1.0:
   version "4.2.0"
@@ -271,12 +275,12 @@ babel-helpers@^6.24.1:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
 
-babel-jest@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.0.6.tgz#807a2a5f5fad7789c57174a955cd14b11045299f"
+babel-jest@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-22.4.3.tgz#4b7a0b6041691bbd422ab49b3b73654a49a6627a"
   dependencies:
     babel-plugin-istanbul "^4.1.5"
-    babel-preset-jest "^22.0.6"
+    babel-preset-jest "^22.4.3"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -292,19 +296,19 @@ babel-plugin-istanbul@^4.1.5:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
-babel-plugin-jest-hoist@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.0.6.tgz#551269ded350a15d6585da35d16d449df30d66c4"
+babel-plugin-jest-hoist@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
-babel-preset-jest@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.0.6.tgz#d13202533db9495c98663044d9f51b273d3984c8"
+babel-preset-jest@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
   dependencies:
-    babel-plugin-jest-hoist "^22.0.6"
+    babel-plugin-jest-hoist "^22.4.3"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:
@@ -707,7 +711,7 @@ doctrine@1.5.0:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
-doctrine@^2.0.2:
+doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
@@ -797,25 +801,25 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.9"
     resolve "^1.5.0"
 
-eslint-module-utils@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
+eslint-module-utils@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz#b270362cd88b1a48ad308976ce7fa54e98411746"
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
 
-eslint-plugin-import@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz#fa1b6ef31fcb3c501c09859c1b86f1fc5b986894"
+eslint-plugin-import@^2.10.0:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.10.0.tgz#fa09083d5a75288df9c6c7d09fe12255985655e7"
   dependencies:
     builtin-modules "^1.1.1"
     contains-path "^0.1.0"
     debug "^2.6.8"
     doctrine "1.5.0"
     eslint-import-resolver-node "^0.3.1"
-    eslint-module-utils "^2.1.1"
+    eslint-module-utils "^2.2.0"
     has "^1.0.1"
-    lodash.cond "^4.3.0"
+    lodash "^4.17.4"
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
@@ -834,9 +838,9 @@ eslint-visitor-keys@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
-eslint@^4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.15.0.tgz#89ab38c12713eec3d13afac14e4a89e75ef08145"
+eslint@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   dependencies:
     ajv "^5.3.0"
     babel-code-frame "^6.22.0"
@@ -844,10 +848,10 @@ eslint@^4.15.0:
     concat-stream "^1.6.0"
     cross-spawn "^5.1.0"
     debug "^3.1.0"
-    doctrine "^2.0.2"
+    doctrine "^2.1.0"
     eslint-scope "^3.7.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^3.5.2"
+    espree "^3.5.4"
     esquery "^1.0.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
@@ -869,18 +873,19 @@ eslint@^4.15.0:
     path-is-inside "^1.0.2"
     pluralize "^7.0.0"
     progress "^2.0.0"
+    regexpp "^1.0.1"
     require-uncached "^1.0.3"
     semver "^5.3.0"
     strip-ansi "^4.0.0"
     strip-json-comments "~2.0.1"
-    table "^4.0.1"
+    table "4.0.2"
     text-table "~0.2.0"
 
-espree@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.2.tgz#756ada8b979e9dcfcdb30aad8d1a9304a905e1ca"
+espree@^3.5.4:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.4.tgz#b0f447187c8a8bed944b815a660bddf5deb5d1a7"
   dependencies:
-    acorn "^5.2.1"
+    acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
 esprima@^3.1.3:
@@ -930,6 +935,10 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exit@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
+
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -942,16 +951,16 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-22.0.6.tgz#69e1761ecb5ba354513e546e6187beda79e18078"
+expect@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
   dependencies:
     ansi-styles "^3.2.0"
-    jest-diff "^22.0.6"
-    jest-get-type "^22.0.6"
-    jest-matcher-utils "^22.0.6"
-    jest-message-util "^22.0.6"
-    jest-regex-util "^22.0.6"
+    jest-diff "^22.4.3"
+    jest-get-type "^22.4.3"
+    jest-matcher-utils "^22.4.3"
+    jest-message-util "^22.4.3"
+    jest-regex-util "^22.4.3"
 
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
@@ -1341,6 +1350,13 @@ ignore@^3.3.3:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
+import-local@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-1.0.0.tgz#5e4ffdc03f4fe6c009c6729beb29631c2f8227bc"
+  dependencies:
+    pkg-dir "^2.0.0"
+    resolve-cwd "^2.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -1608,40 +1624,43 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-jest-changed-files@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.0.6.tgz#fca38cf4c89920c66aad1707e91d25bbea238875"
+jest-changed-files@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-22.4.3.tgz#8882181e022c38bd46a2e4d18d44d19d90a90fb2"
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.0.6.tgz#a2f1e5e094c42b29d22815463ae57f4d07e292ac"
+jest-cli@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-22.4.3.tgz#bf16c4a5fb7edc3fa5b9bb7819e34139e88a72c7"
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
+    exit "^0.1.2"
     glob "^7.1.2"
     graceful-fs "^4.1.11"
+    import-local "^1.0.0"
     is-ci "^1.0.10"
     istanbul-api "^1.1.14"
     istanbul-lib-coverage "^1.1.1"
     istanbul-lib-instrument "^1.8.0"
     istanbul-lib-source-maps "^1.2.1"
-    jest-changed-files "^22.0.6"
-    jest-config "^22.0.6"
-    jest-environment-jsdom "^22.0.6"
-    jest-get-type "^22.0.6"
-    jest-haste-map "^22.0.6"
-    jest-message-util "^22.0.6"
-    jest-regex-util "^22.0.6"
-    jest-resolve-dependencies "^22.0.6"
-    jest-runner "^22.0.6"
-    jest-runtime "^22.0.6"
-    jest-snapshot "^22.0.6"
-    jest-util "^22.0.6"
-    jest-worker "^22.0.6"
+    jest-changed-files "^22.4.3"
+    jest-config "^22.4.3"
+    jest-environment-jsdom "^22.4.3"
+    jest-get-type "^22.4.3"
+    jest-haste-map "^22.4.3"
+    jest-message-util "^22.4.3"
+    jest-regex-util "^22.4.3"
+    jest-resolve-dependencies "^22.4.3"
+    jest-runner "^22.4.3"
+    jest-runtime "^22.4.3"
+    jest-snapshot "^22.4.3"
+    jest-util "^22.4.3"
+    jest-validate "^22.4.3"
+    jest-worker "^22.4.3"
     micromatch "^2.3.11"
-    node-notifier "^5.1.2"
+    node-notifier "^5.2.1"
     realpath-native "^1.0.0"
     rimraf "^2.5.4"
     slash "^1.0.0"
@@ -1650,100 +1669,101 @@ jest-cli@^22.0.6:
     which "^1.2.12"
     yargs "^10.0.3"
 
-jest-config@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.0.6.tgz#8af116784df189b98ed6fd6c307bce4181f7f012"
+jest-config@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-22.4.3.tgz#0e9d57db267839ea31309119b41dc2fa31b76403"
   dependencies:
     chalk "^2.0.1"
     glob "^7.1.1"
-    jest-environment-jsdom "^22.0.6"
-    jest-environment-node "^22.0.6"
-    jest-get-type "^22.0.6"
-    jest-jasmine2 "^22.0.6"
-    jest-regex-util "^22.0.6"
-    jest-resolve "^22.0.6"
-    jest-util "^22.0.6"
-    jest-validate "^22.0.6"
-    pretty-format "^22.0.6"
+    jest-environment-jsdom "^22.4.3"
+    jest-environment-node "^22.4.3"
+    jest-get-type "^22.4.3"
+    jest-jasmine2 "^22.4.3"
+    jest-regex-util "^22.4.3"
+    jest-resolve "^22.4.3"
+    jest-util "^22.4.3"
+    jest-validate "^22.4.3"
+    pretty-format "^22.4.3"
 
-jest-diff@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.0.6.tgz#38c07187324564ecf6389a980a2f0e86e7e79890"
+jest-diff@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-22.4.3.tgz#e18cc3feff0aeef159d02310f2686d4065378030"
   dependencies:
     chalk "^2.0.1"
     diff "^3.2.0"
-    jest-get-type "^22.0.6"
-    pretty-format "^22.0.6"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
-jest-docblock@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.0.6.tgz#f187fb2c67eec0999e569d563092125283084f9e"
+jest-docblock@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-22.4.3.tgz#50886f132b42b280c903c592373bb6e93bb68b19"
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.0.6.tgz#243f3fa7167a1f293410aec8d3eb12ab8de4f748"
+jest-environment-jsdom@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-22.4.3.tgz#d67daa4155e33516aecdd35afd82d4abf0fa8a1e"
   dependencies:
-    jest-mock "^22.0.6"
-    jest-util "^22.0.6"
+    jest-mock "^22.4.3"
+    jest-util "^22.4.3"
     jsdom "^11.5.1"
 
-jest-environment-node@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.0.6.tgz#4f34ac4c0591297aceefa6a93421360bd56e5a74"
+jest-environment-node@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-22.4.3.tgz#54c4eaa374c83dd52a9da8759be14ebe1d0b9129"
   dependencies:
-    jest-mock "^22.0.6"
-    jest-util "^22.0.6"
+    jest-mock "^22.4.3"
+    jest-util "^22.4.3"
 
-jest-get-type@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.0.6.tgz#301fbc0760779fdbad37b6e3239a3c1811aa75cb"
+jest-get-type@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
 
-jest-haste-map@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.0.6.tgz#198d665f65e1c484fef106a3c970c5b47903647e"
+jest-haste-map@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-22.4.3.tgz#25842fa2ba350200767ac27f658d58b9d5c2e20b"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^22.0.6"
-    jest-worker "^22.0.6"
+    jest-docblock "^22.4.3"
+    jest-serializer "^22.4.3"
+    jest-worker "^22.4.3"
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.0.6.tgz#db9eae709978a8d67a52f7b90d74cab7301107f5"
+jest-jasmine2@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-22.4.3.tgz#4daf64cd14c793da9db34a7c7b8dcfe52a745965"
   dependencies:
-    callsites "^2.0.0"
     chalk "^2.0.1"
     co "^4.6.0"
-    expect "^22.0.6"
+    expect "^22.4.3"
     graceful-fs "^4.1.11"
     is-generator-fn "^1.0.0"
-    jest-diff "^22.0.6"
-    jest-matcher-utils "^22.0.6"
-    jest-message-util "^22.0.6"
-    jest-snapshot "^22.0.6"
+    jest-diff "^22.4.3"
+    jest-matcher-utils "^22.4.3"
+    jest-message-util "^22.4.3"
+    jest-snapshot "^22.4.3"
+    jest-util "^22.4.3"
     source-map-support "^0.5.0"
 
-jest-leak-detector@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.0.6.tgz#e983e6fca0959f095cd5b39df2a9a8c956f45988"
+jest-leak-detector@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
   dependencies:
-    pretty-format "^22.0.6"
+    pretty-format "^22.4.3"
 
-jest-matcher-utils@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.0.6.tgz#55675242b2af1de913f44e00aa4d68a38d349b07"
+jest-matcher-utils@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.0.6"
-    pretty-format "^22.0.6"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
-jest-message-util@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.0.6.tgz#2b30edce5131a9358f529ad66ff84835ba4ed457"
+jest-message-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-22.4.3.tgz#cf3d38aafe4befddbfc455e57d65d5239e399eb7"
   dependencies:
     "@babel/code-frame" "^7.0.0-beta.35"
     chalk "^2.0.1"
@@ -1751,57 +1771,60 @@ jest-message-util@^22.0.6:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.0.6.tgz#0d1f51ec2bf1e72cd58e79cb76f587e6397306ec"
+jest-mock@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
 
-jest-regex-util@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.0.6.tgz#cd01d33c5993340f5d61be09b270773787a41d88"
+jest-regex-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
 
-jest-resolve-dependencies@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.0.6.tgz#dd976f0a9c2874d32edf4876b0a965cef48d479b"
+jest-resolve-dependencies@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-22.4.3.tgz#e2256a5a846732dc3969cb72f3c9ad7725a8195e"
   dependencies:
-    jest-regex-util "^22.0.6"
+    jest-regex-util "^22.4.3"
 
-jest-resolve@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.0.6.tgz#29d7aa425adb9aae7aa5ae157483dffba724e52b"
+jest-resolve@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-22.4.3.tgz#0ce9d438c8438229aa9b916968ec6b05c1abb4ea"
   dependencies:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
 
-jest-runner@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.0.6.tgz#1986ee82b7968d21f04c402e5b67e3da71496f19"
+jest-runner@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-22.4.3.tgz#298ddd6a22b992c64401b4667702b325e50610c3"
   dependencies:
-    jest-config "^22.0.6"
-    jest-docblock "^22.0.6"
-    jest-haste-map "^22.0.6"
-    jest-jasmine2 "^22.0.6"
-    jest-leak-detector "^22.0.6"
-    jest-message-util "^22.0.6"
-    jest-runtime "^22.0.6"
-    jest-util "^22.0.6"
-    jest-worker "^22.0.6"
+    exit "^0.1.2"
+    jest-config "^22.4.3"
+    jest-docblock "^22.4.3"
+    jest-haste-map "^22.4.3"
+    jest-jasmine2 "^22.4.3"
+    jest-leak-detector "^22.4.3"
+    jest-message-util "^22.4.3"
+    jest-runtime "^22.4.3"
+    jest-util "^22.4.3"
+    jest-worker "^22.4.3"
     throat "^4.0.0"
 
-jest-runtime@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.0.6.tgz#827c35e706adfc22e685de733ba3ab78cda72bfc"
+jest-runtime@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-22.4.3.tgz#b69926c34b851b920f666c93e86ba2912087e3d0"
   dependencies:
     babel-core "^6.0.0"
-    babel-jest "^22.0.6"
+    babel-jest "^22.4.3"
     babel-plugin-istanbul "^4.1.5"
     chalk "^2.0.1"
     convert-source-map "^1.4.0"
+    exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^22.0.6"
-    jest-haste-map "^22.0.6"
-    jest-regex-util "^22.0.6"
-    jest-resolve "^22.0.6"
-    jest-util "^22.0.6"
+    jest-config "^22.4.3"
+    jest-haste-map "^22.4.3"
+    jest-regex-util "^22.4.3"
+    jest-resolve "^22.4.3"
+    jest-util "^22.4.3"
+    jest-validate "^22.4.3"
     json-stable-stringify "^1.0.1"
     micromatch "^2.3.11"
     realpath-native "^1.0.0"
@@ -1810,49 +1833,55 @@ jest-runtime@^22.0.6:
     write-file-atomic "^2.1.0"
     yargs "^10.0.3"
 
-jest-snapshot@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.0.6.tgz#30c1f85b6f050891c4a2060d807a3d65a594591c"
+jest-serializer@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
+
+jest-snapshot@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-22.4.3.tgz#b5c9b42846ffb9faccb76b841315ba67887362d2"
   dependencies:
     chalk "^2.0.1"
-    jest-diff "^22.0.6"
-    jest-matcher-utils "^22.0.6"
+    jest-diff "^22.4.3"
+    jest-matcher-utils "^22.4.3"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    pretty-format "^22.0.6"
+    pretty-format "^22.4.3"
 
-jest-util@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.0.6.tgz#539b3f21f4e2e458bb38719aa0e417109fe31657"
+jest-util@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-22.4.3.tgz#c70fec8eec487c37b10b0809dc064a7ecf6aafac"
   dependencies:
     callsites "^2.0.0"
     chalk "^2.0.1"
     graceful-fs "^4.1.11"
     is-ci "^1.0.10"
-    jest-message-util "^22.0.6"
-    jest-validate "^22.0.6"
+    jest-message-util "^22.4.3"
     mkdirp "^0.5.1"
+    source-map "^0.6.0"
 
-jest-validate@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.0.6.tgz#48c6972f154fa4abe20d0686a9b819d142740167"
+jest-validate@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-22.4.3.tgz#0780954a5a7daaeec8d3c10834b9280865976b30"
   dependencies:
     chalk "^2.0.1"
-    jest-get-type "^22.0.6"
+    jest-config "^22.4.3"
+    jest-get-type "^22.4.3"
     leven "^2.1.0"
-    pretty-format "^22.0.6"
+    pretty-format "^22.4.3"
 
-jest-worker@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.0.6.tgz#1998ac7ab24a6eee4deddec76efe7742f2651504"
+jest-worker@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-22.0.6.tgz#0d0d3bdc402c43cf5a3eae58a55cff6da8b6820f"
+jest@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-22.4.3.tgz#2261f4b117dc46d9a4a1a673d2150958dee92f16"
   dependencies:
-    jest-cli "^22.0.6"
+    import-local "^1.0.0"
+    jest-cli "^22.4.3"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -2004,10 +2033,6 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash.cond@^4.3.0:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -2138,14 +2163,14 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+node-notifier@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
   dependencies:
     growly "^1.3.0"
-    semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
+    semver "^5.4.1"
+    shellwords "^0.1.1"
+    which "^1.3.0"
 
 node-pre-gyp@^0.6.39:
   version "0.6.39"
@@ -2396,6 +2421,12 @@ pkg-dir@^1.0.0:
   dependencies:
     find-up "^1.0.0"
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  dependencies:
+    find-up "^2.1.0"
+
 pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
@@ -2412,13 +2443,13 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+prettier@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
 
-pretty-format@^22.0.6:
-  version "22.0.6"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.0.6.tgz#bbb78e38445f263c2d3b9e281f4b844380990720"
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -2533,6 +2564,10 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regexpp@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-1.1.0.tgz#0e3516dd0b7904f413d2d4193dce4618c3a689ab"
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
@@ -2634,9 +2669,19 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+resolve-cwd@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"
+  dependencies:
+    resolve-from "^3.0.0"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
+
+resolve-from@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
 resolve@1.1.7:
   version "1.1.7"
@@ -2713,6 +2758,10 @@ sax@^1.2.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -2727,7 +2776,7 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shellwords@^0.1.0:
+shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
@@ -2905,7 +2954,7 @@ symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
-table@^4.0.1:
+table@4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/table/-/table-4.0.2.tgz#a33447375391e766ad34d3486e6e2aedc84d2e36"
   dependencies:
@@ -3095,7 +3144,7 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.12, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,18 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-filter@~0.0.0:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/array-filter/-/array-filter-0.0.1.tgz#7da8cf2e26628ed732803581fd21f67cacd2eeec"
+
+array-map@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-map/-/array-map-0.0.0.tgz#88a2bab73d1cf7bcd5c1b118a003f66f665fa662"
+
+array-reduce@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -721,6 +733,10 @@ domexception@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.0.tgz#81fe5df81b3f057052cde3a9fa9bf536a85b9ab0"
 
+duplexer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
+
 ecc-jsbn@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
@@ -733,11 +749,21 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-error-ex@^1.2.0:
+error-ex@^1.2.0, error-ex@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
   dependencies:
     is-arrayish "^0.2.1"
+
+es-abstract@^1.4.3:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.11.0.tgz#cce87d518f0496893b1a30cd8461835535480681"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
 
 es-abstract@^1.5.1:
   version "1.10.0"
@@ -917,11 +943,35 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
+event-stream@~3.3.0:
+  version "3.3.4"
+  resolved "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz#4ab4c9a0f5a54db9338b4c34d86bfce8f4b35571"
+  dependencies:
+    duplexer "~0.1.1"
+    from "~0"
+    map-stream "~0.1.0"
+    pause-stream "0.0.11"
+    split "0.3"
+    stream-combiner "~0.0.4"
+    through "~2.3.1"
+
 exec-sh@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.1.tgz#163b98a6e89e6b65b47c2a28d215bc1f63989c38"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^0.7.0:
   version "0.7.0"
@@ -1095,6 +1145,10 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+from@~0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/from/-/from-0.1.7.tgz#83c60afc58b9c56997007ed1a768b3ab303a44fe"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1931,6 +1985,10 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+
 json-schema-traverse@^0.3.0:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
@@ -2026,6 +2084,15 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
@@ -2064,11 +2131,19 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-stream@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
   dependencies:
     mimic-fn "^1.0.0"
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
 
 merge-stream@^1.0.1:
   version "1.0.1"
@@ -2210,6 +2285,20 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
+npm-run-all@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.2.tgz#90d62d078792d20669139e718621186656cea056"
+  dependencies:
+    ansi-styles "^3.2.0"
+    chalk "^2.1.0"
+    cross-spawn "^5.1.0"
+    memorystream "^0.3.1"
+    minimatch "^3.0.4"
+    ps-tree "^1.1.0"
+    read-pkg "^3.0.0"
+    shell-quote "^1.6.1"
+    string.prototype.padend "^3.0.0"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -2347,6 +2436,13 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse5@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
@@ -2393,6 +2489,18 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
+
+pause-stream@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
+  dependencies:
+    through "~2.3"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -2404,6 +2512,10 @@ performance-now@^2.1.0:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -2443,6 +2555,12 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier-check@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-check/-/prettier-check-2.0.0.tgz#edd086ee12d270579233ccb136a16e6afcfba1ae"
+  dependencies:
+    execa "^0.6.0"
+
 prettier@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
@@ -2469,6 +2587,12 @@ progress@2.0.0, progress@^2.0.0:
 proxy-from-env@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
+ps-tree@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ps-tree/-/ps-tree-1.1.0.tgz#b421b24140d6203f1ed3c76996b4427b08e8c014"
+  dependencies:
+    event-stream "~3.3.0"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -2535,6 +2659,14 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2:
   version "2.3.3"
@@ -2776,6 +2908,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
+shell-quote@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
+  dependencies:
+    array-filter "~0.0.0"
+    array-map "~0.0.0"
+    array-reduce "~0.0.0"
+    jsonify "~0.0.0"
+
 shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
@@ -2846,6 +2987,12 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split@0.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  dependencies:
+    through "2"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -2872,6 +3019,12 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+stream-combiner@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/stream-combiner/-/stream-combiner-0.0.4.tgz#4d5e433c185261dde623ca3f44c586bcf5c4ad14"
+  dependencies:
+    duplexer "~0.1.1"
+
 string-length@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-2.0.0.tgz#d40dbb686a3ace960c1cffca562bf2c45f8363ed"
@@ -2893,6 +3046,14 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
+
+string.prototype.padend@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz#f3aaef7c1719f170c5eab1c32bf780d96e21f2f0"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.4.3"
+    function-bind "^1.0.2"
 
 string_decoder@~1.0.3:
   version "1.0.3"
@@ -3004,7 +3165,7 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
-through@^2.3.6:
+through@2, through@^2.3.6, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,11 +10,14 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@sentry/cli@^1.28.1":
-  version "1.28.1"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.28.1.tgz#42feaa7f5db056dad1ebfbb80af5c01c1f46b82d"
+"@sentry/cli@^1.30.2":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.30.3.tgz#02d0f7781c1ee5e1be5a4312a325fbe8b1b37231"
   dependencies:
+    https-proxy-agent "^2.1.1"
+    node-fetch "^1.7.3"
     progress "2.0.0"
+    proxy-from-env "^1.0.0"
 
 "@types/node@*":
   version "9.3.0"
@@ -47,6 +50,12 @@ acorn@^3.0.4:
 acorn@^5.0.0, acorn@^5.1.2, acorn@^5.2.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.3.0.tgz#7446d39459c54fb49a80e6ee6478149b940ec822"
+
+agent-base@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.2.0.tgz#9838b5c3392b962bad031e6a4c5e1024abec45ce"
+  dependencies:
+    es6-promisify "^5.0.0"
 
 ajv-keywords@^2.1.0:
   version "2.1.1"
@@ -714,6 +723,12 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -737,6 +752,16 @@ es-to-primitive@^1.1.1:
     is-callable "^1.1.1"
     is-date-object "^1.0.1"
     is-symbol "^1.0.1"
+
+es6-promise@^4.0.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.4.tgz#dc4221c2b16518760bd8c39a52d8f356fc00ed29"
+
+es6-promisify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
+  dependencies:
+    es6-promise "^4.0.3"
 
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1295,9 +1320,22 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+https-proxy-agent@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz#51552970fa04d723e04c56d04178c3f92592bbc0"
+  dependencies:
+    agent-base "^4.1.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@~0.4.13:
+  version "0.4.21"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
+  dependencies:
+    safer-buffer "^2.1.0"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -1473,7 +1511,7 @@ is-resolvable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.1.tgz#acca1cd36dbe44b974b924321555a70ba03b1cf4"
 
-is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2089,6 +2127,13 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
+node-fetch@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2390,6 +2435,10 @@ progress@2.0.0, progress@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.0.tgz#8a1be366bf8fc23db2bd23f10c6fe920b4389d1f"
 
+proxy-from-env@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+
 pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
@@ -2637,6 +2686,10 @@ rx-lite@*, rx-lite@^4.0.8:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^2.0.0:
   version "2.2.0"


### PR DESCRIPTION
This implements a feature request from #37 that allows to skip certain entry points via the `entry` option. The actual feature commit is 67901a7.

Since the code was not yet documented and test coverage was pretty low, I also refactored the whole thing and added more tests. It **should** now better live up to our usual coding standards. Test coverage is at nearly 100%, except for the dry-run CLI mock. 

Tests have been added for our modifications to the compiler options (namely `entry` and `module.rules`/`module.loaders`), which were previously untested. This should also make it easier to test certain webpack configurations, once we receive them from users.