### PR TITLE
Allow [hash] usage in release option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ Also, check the [example](example) directory.
 * `release [optional]` - unique name of a release, must be a `string`, should
   uniquely identify your release, defaults to
   `sentry-cli releases propose-version` command which should always return the
-  correct version
+  correct version. Can use `[hash]` as a part of a string, which will be replaced
+  with Webpack's compilation hash.
 * `include [required]` - `string` or `array`, one or more paths that Sentry CLI
   should scan recursively for sources. It will upload all `.map` files and match
   associated `.js` files

--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ class SentryCliPlugin {
     let release;
     return this.release
       .then(proposedVersion => {
-        release = proposedVersion;
+        release = proposedVersion.replace('[hash]', compilation.hash);
         return this.cli.releases.new(release);
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))


### PR DESCRIPTION
Resolves https://github.com/getsentry/sentry-webpack-plugin/issues/66