### PR TITLE
Remove [hash] support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ Also, check the [example](example) directory.
   uniquely identify your release, defaults to
   `sentry-cli releases propose-version` command which should always return the
   correct version (**requires access to `git` CLI and root directory to be a valid
-  repository**). Can use `[hash]` as a part of a string, which will be replaced
-  with Webpack's compilation hash.
+  repository**).
 * `include [required]` - `string` or `array`, one or more paths that Sentry CLI
   should scan recursively for sources. It will upload all `.map` files and match
   associated `.js` files

--- a/src/index.js
+++ b/src/index.js
@@ -290,7 +290,7 @@ class SentryCliPlugin {
     let release;
     return this.release
       .then(proposedVersion => {
-        release = proposedVersion.replace('[hash]', compilation.hash);
+        release = proposedVersion;
         return this.cli.releases.new(release);
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))


### PR DESCRIPTION
I completely forgot that hash is available only after the loader compiled the module file we inject 🤦‍♂️ 
There's no need for a new release, as barely anyone uses this feature (it's only available <24h).

Ref: https://github.com/getsentry/sentry-webpack-plugin/issues/80