### PR TITLE
Fix global check in loader

### DIFF
--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -2,8 +2,7 @@ module.exports = function sentryLoader(content, map, meta) {
   const { releasePromise } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    const sentryRelease =
-      `(typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : self).SENTRY_RELEASE={id:"${version}"};`;
+    const sentryRelease = `(typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : self).SENTRY_RELEASE={id:"${version}"};`;
     callback(null, sentryRelease, map, meta);
   });
 };

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -2,7 +2,8 @@ module.exports = function sentryLoader(content, map, meta) {
   const { releasePromise } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    const sentryRelease = `(window||global||self).SENTRY_RELEASE={id:"${version}"};`;
+    const sentryRelease =
+      `(typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : self).SENTRY_RELEASE={id:"${version}"};`;
     callback(null, sentryRelease, map, meta);
   });
 };


### PR DESCRIPTION
Accessing a global that doesn't exist crashes in node, we need to use `typeof x !== "undefined"`, this is what usually used to handle globals in different environments properly.