### PR TITLE
Add errorHandler option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Also, check the [example](example) directory.
   environments)
 * `debug [optional]` - `boolean`, print some useful debug information
 * `silent [optional]` - `boolean`, if `true`, all logs are suppressed (useful for `--json` option)
+* `errorHandler [optional]` - `function(err: Error, invokeErr: function(): void): void`, when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr() }`
 
 You can find more information about these options in our official docs:
 https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -202,6 +202,30 @@ describe('afterEmitHook', () => {
       done();
     });
   });
+
+  test('handles errors with errorHandler option', done => {
+    expect.assertions(3);
+    mockCli.releases.new.mockImplementationOnce(() =>
+      Promise.reject(new Error('Pickle Rick'))
+    );
+    let e;
+
+    const sentryCliPlugin = new SentryCliPlugin({
+      include: 'src',
+      release: 42,
+      errorHandler: err => {
+        e = err;
+      },
+    });
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(compilation.errors).toEqual([]);
+      expect(e.message).toEqual('Pickle Rick');
+      expect(compilationDoneCallback).toBeCalled();
+      done();
+    });
+  });
 });
 
 describe('module rule overrides', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -298,7 +298,12 @@ class SentryCliPlugin {
 
   /** Creates and finalizes a release on Sentry. */
   finalizeRelease(compilation) {
-    const { include } = this.options;
+    const {
+      include,
+      errorHandler = (err, invokeErr) => {
+        invokeErr();
+      },
+    } = this.options;
 
     if (!include) {
       addCompilationError(compilation, '`include` option is required');
@@ -313,7 +318,9 @@ class SentryCliPlugin {
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => this.cli.releases.finalize(release))
-      .catch(err => addCompilationError(compilation, err.message));
+      .catch(err =>
+        errorHandler(err, () => addCompilationError(compilation, err.message))
+      );
   }
 
   /** Webpack lifecycle hook to update compiler options. */


### PR DESCRIPTION
I am using on-premise version sentry on my workspace and it works amazingly except occasional build failure on CI server caused by a network issue.

#75, #100 and some more issues are complaining sentry error, and I guess they are suffered from a network limit like me. I cannot change my company's network policy, so, at least I need building my project with sentry release failure.

Sentry plugin is not a code processor and it does not directly affect the compiled code. It is plugin with side effect and IO, and there always is a possibility to fail regardless of the code itself. So, IMO it would be quite reasonable that users have the right to choose ignoring sentry plugin error.

I added `errorHandler` option. check-up, please?