### PR TITLE
feat: Add setCommits option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Also, check the [example](example) directory.
 * `debug [optional]` - `boolean`, print some useful debug information
 * `silent [optional]` - `boolean`, if `true`, all logs are suppressed (useful for `--json` option)
 * `errorHandler [optional]` - `function(err: Error, invokeErr: function(): void): void`, when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr() }`
+* `commit [optional]` - `string`, the current (last) commit in the release
+* `previousCommit [optional]` - `string`, the commit before the beginning of this release (in other words, the last commit of the previous release). If omitted, this will default to the last commit of the previous release in Sentry. If there was no previous release, the last 10 commits will be used
+* `repo [optional]` - `string`, the full repo name as defined in Sentry
+* `auto [optional]` - `boolean`, automatically choose the associated commit (uses the current commit). Overrides other options
 
 You can find more information about these options in our official docs:
 https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Also, check the [example](example) directory.
 * `debug [optional]` - `boolean`, print some useful debug information
 * `silent [optional]` - `boolean`, if `true`, all logs are suppressed (useful for `--json` option)
 * `errorHandler [optional]` - `function(err: Error, invokeErr: function(): void): void`, when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr() }`
+
+set-commits options:
 * `commit [optional]` - `string`, the current (last) commit in the release
 * `previousCommit [optional]` - `string`, the commit before the beginning of this release (in other words, the last commit of the previous release). If omitted, this will default to the last commit of the previous release in Sentry. If there was no previous release, the last 10 commits will be used
 * `repo [optional]` - `string`, the full repo name as defined in Sentry

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -9,6 +9,7 @@ const mockCli = {
     uploadSourceMaps: jest.fn(() => Promise.resolve()),
     finalize: jest.fn(() => Promise.resolve()),
     proposeVersion: jest.fn(() => Promise.resolve()),
+    setCommits: jest.fn(() => Promise.resolve()),
   },
 };
 

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -227,6 +227,49 @@ describe('afterEmitHook', () => {
       done();
     });
   });
+
+  test('test setCommits with commits range', done => {
+    const sentryCliPlugin = new SentryCliPlugin({
+      include: 'src',
+      release: '42',
+      commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+      previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+      repo: 'group / repo',
+      // auto,
+    });
+
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(mockCli.releases.setCommits).toBeCalledWith('42', {
+        repo: 'group / repo',
+        commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+        previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+      });
+      expect(compilationDoneCallback).toBeCalled();
+      done();
+    });
+  });
+
+  test('test setCommits with auto option', done => {
+    const sentryCliPlugin = new SentryCliPlugin({
+      include: 'src',
+      release: '42',
+      repo: 'group / repo',
+      auto: true,
+    });
+
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(mockCli.releases.setCommits).toBeCalledWith('42', {
+        repo: 'group / repo',
+        auto: true,
+      });
+      expect(compilationDoneCallback).toBeCalled();
+      done();
+    });
+  });
 });
 
 describe('module rule overrides', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -322,13 +322,13 @@ class SentryCliPlugin {
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => {
-        const { commit, previousCommit, repo, auto } = this.options
+        const { commit, previousCommit, repo, auto } = this.options;
 
         if (commit || previousCommit || repo || auto) {
-          return this.cli.releases.setCommits(release, this.options)
+          return this.cli.releases.setCommits(release, this.options);
         }
 
-        return undefined
+        return undefined;
       })
       .then(() => this.cli.releases.finalize(release))
       .catch(err =>

--- a/src/index.js
+++ b/src/index.js
@@ -325,15 +325,13 @@ class SentryCliPlugin {
         const { commit, previousCommit, repo, auto } = this.options;
 
         if (repo && ((commit && previousCommit) || auto)) {
-          return this.cli.releases.setCommits(release, {
+          this.cli.releases.setCommits(release, {
             commit,
             previousCommit,
             repo,
             auto,
           });
         }
-
-        return undefined;
       })
       .then(() => this.cli.releases.finalize(release))
       .catch(err =>

--- a/src/index.js
+++ b/src/index.js
@@ -324,8 +324,13 @@ class SentryCliPlugin {
       .then(() => {
         const { commit, previousCommit, repo, auto } = this.options;
 
-        if (commit || previousCommit || repo || auto) {
-          return this.cli.releases.setCommits(release, this.options);
+        if (repo && ((commit && previousCommit) || auto)) {
+          return this.cli.releases.setCommits(release, {
+            commit,
+            previousCommit,
+            repo,
+            auto,
+          });
         }
 
         return undefined;

--- a/src/index.js
+++ b/src/index.js
@@ -151,6 +151,10 @@ class SentryCliPlugin {
             this.outputDebug('Finalizing release:\n', release);
             return Promise.resolve(release);
           },
+          setCommits: (release, config) => {
+            this.outputDebug('Calling set-commits with:\n', config);
+            return Promise.resolve(release, config);
+          },
         },
       };
     }
@@ -317,6 +321,15 @@ class SentryCliPlugin {
         return this.cli.releases.new(release);
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
+      .then(() => {
+        const { commit, previousCommit, repo, auto } = this.options
+
+        if (commit || previousCommit || repo || auto) {
+          return this.cli.releases.setCommits(release, this.options)
+        }
+
+        return undefined
+      })
       .then(() => this.cli.releases.finalize(release))
       .catch(err =>
         errorHandler(err, () => addCompilationError(compilation, err.message))

--- a/src/index.js
+++ b/src/index.js
@@ -324,7 +324,7 @@ class SentryCliPlugin {
       .then(() => {
         const { commit, previousCommit, repo, auto } = this.options;
 
-        if (repo && ((commit && previousCommit) || auto)) {
+        if (repo && (commit || auto)) {
           this.cli.releases.setCommits(release, {
             commit,
             previousCommit,


### PR DESCRIPTION
I added setCommits command to be able set associated commits through this plugin as requested here #71. Without this options you forced to use sentry-cli to set associated commits directly. Please check this out.

ToDo:
- [x] add tests for setCommits
- [x] update setCommits options descriptions in README.md