### PR TITLE
[Suggestion] - Nested setCommits & readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ entries | `array`/`RegExp`/`function(key: string): bool` | optional | a filter f
 | setCommits | `Object` | optional | Adds commits to sentry - [see own table below](#setCommits) for more details |
 
 
-#### <a name="setCommits"></a>setCommits:
+#### <a name="setCommits"></a>options.setCommits:
 
 | Option | Type | Required | Description |
 ---------|------|----------|-------------

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ Also, check the [example](example) directory.
 
 #### Options
 
-Option | Type | Required | Description |
--------|------|----------|-------------
+| Option | Type | Required | Description |
+---------|------|----------|-------------
 release | `string` | optional | unique name of a release, must be a `string`, should uniquely identify your release, defaults to `sentry-cli releases propose-version` command which should always return the correct version (**requires access to `git` CLI and root directory to be a valid repository**).
 include | `string`/`array` | required | one or more paths that Sentry CLI should scan recursively for sources. It will upload all `.map` files and match associated `.js` files |
 entries | `array`/`RegExp`/`function(key: string): bool` | optional | a filter for entry points that should be processed. By default, the release will be injected into all entry points. |
@@ -79,13 +79,17 @@ entries | `array`/`RegExp`/`function(key: string): bool` | optional | a filter f
 | debug | `boolean` | optional | print some useful debug information |
 | silent | `boolean` | optional | if `true`, all logs are suppressed (useful for `--json` option) |
 | errorHandler | `function(err: Error, invokeErr: function(): void): void` | optional | when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr()}` |
+| setCommits | `Object` | optional | Adds commits to sentry - [see own table below](#setCommits) for more details |
 
 
-##### setCommits:
-* `repo [required]` - `string`, the full git repo name as defined in Sentry
-* `commit [optional/required]` - `string`, the current (last) commit in the release
-* `previousCommit [optional]` - `string`, the commit before the beginning of this release (in other words, the last commit of the previous release). If omitted, this will default to the last commit of the previous release in Sentry. If there was no previous release, the last 10 commits will be used
-* `auto [optional/required]` - `boolean`, automatically choose the associated commit (uses the current commit). Overrides other options
+#### <a name="setCommits"></a>setCommits:
+
+| Option | Type | Required | Description |
+---------|------|----------|-------------
+| repo | `string` | required | the full git repo name as defined in Sentry |
+| commit | `string` | optional/required | the current (last) commit in the release |
+| previousCommit | `string` | optional | the commit before the beginning of this release (in other words, the last commit of the previous release). If omitted, this will default to the last commit of the previous release in Sentry. If there was no previous release, the last 10 commits will be used |
+| auto | `boolean` | optional/required | automatically choose the associated commit (uses the current commit). Overrides other options |
 
 You can find more information about these options in our official docs:
 https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ Also, check the [example](example) directory.
 * `silent [optional]` - `boolean`, if `true`, all logs are suppressed (useful for `--json` option)
 * `errorHandler [optional]` - `function(err: Error, invokeErr: function(): void): void`, when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr() }`
 
-set-commits options:
-* `commit [optional]` - `string`, the current (last) commit in the release
+##### setCommits:
+* `repo [required]` - `string`, the full git repo name as defined in Sentry
+* `commit [optional/required]` - `string`, the current (last) commit in the release
 * `previousCommit [optional]` - `string`, the commit before the beginning of this release (in other words, the last commit of the previous release). If omitted, this will default to the last commit of the previous release in Sentry. If there was no previous release, the last 10 commits will be used
-* `repo [optional]` - `string`, the full repo name as defined in Sentry
-* `auto [optional]` - `boolean`, automatically choose the associated commit (uses the current commit). Overrides other options
+* `auto [optional/required]` - `boolean`, automatically choose the associated commit (uses the current commit). Overrides other options
 
 You can find more information about these options in our official docs:
 https://docs.sentry.io/cli/releases/#sentry-cli-sourcemaps

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -228,15 +228,14 @@ describe('afterEmitHook', () => {
     });
   });
 
-  test('test setCommits with commits range', done => {
+  test('test setCommits with flat options', done => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: 'src',
       release: '42',
-      setCommits: {
-        commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
-        previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
-        repo: 'group / repo',
-      },
+      commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+      previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+      repo: 'group / repo',
+      auto: false,
     });
 
     sentryCliPlugin.apply(compiler);
@@ -246,19 +245,22 @@ describe('afterEmitHook', () => {
         repo: 'group / repo',
         commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
         previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+        auto: false,
       });
       expect(compilationDoneCallback).toBeCalled();
       done();
     });
   });
 
-  test('test setCommits with auto option', done => {
+  test('test setCommits with grouped options', done => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: 'src',
       release: '42',
       setCommits: {
+        commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+        previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
         repo: 'group / repo',
-        auto: true,
+        auto: false,
       },
     });
 
@@ -267,7 +269,9 @@ describe('afterEmitHook', () => {
     setImmediate(() => {
       expect(mockCli.releases.setCommits).toBeCalledWith('42', {
         repo: 'group / repo',
-        auto: true,
+        commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+        previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+        auto: false,
       });
       expect(compilationDoneCallback).toBeCalled();
       done();

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -232,10 +232,11 @@ describe('afterEmitHook', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: 'src',
       release: '42',
-      commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
-      previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
-      repo: 'group / repo',
-      // auto,
+      setCommits: {
+        commit: '4d8656426ca13eab19581499da93408e30fdd9ef',
+        previousCommit: 'b6b0e11e74fd55836d3299cef88531b2a34c2514',
+        repo: 'group / repo',
+      },
     });
 
     sentryCliPlugin.apply(compiler);
@@ -255,8 +256,10 @@ describe('afterEmitHook', () => {
     const sentryCliPlugin = new SentryCliPlugin({
       include: 'src',
       release: '42',
-      repo: 'group / repo',
-      auto: true,
+      setCommits: {
+        repo: 'group / repo',
+        auto: true,
+      },
     });
 
     sentryCliPlugin.apply(compiler);

--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,8 @@ class SentryCliPlugin {
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => {
-        const { commit, previousCommit, repo, auto } = this.options.setCommits || this.options;
+        const { commit, previousCommit, repo, auto } =
+          this.options.setCommits || this.options;
 
         if (repo && (commit || auto)) {
           this.cli.releases.setCommits(release, {

--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,7 @@ class SentryCliPlugin {
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => {
-        const { commit, previousCommit, repo, auto } = this.options;
+        const { commit, previousCommit, repo, auto } = this.options.setCommits;
 
         if (repo && (commit || auto)) {
           this.cli.releases.setCommits(release, {

--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,7 @@ class SentryCliPlugin {
       })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => {
-        const { commit, previousCommit, repo, auto } = this.options.setCommits;
+        const { commit, previousCommit, repo, auto } = this.options.setCommits || this.options;
 
         if (repo && (commit || auto)) {
           this.cli.releases.setCommits(release, {


### PR DESCRIPTION
After the **beautiful** work on the pr #139 finally got released, I implemented it to my org's codebase but in the process, I felt it was missing something:

### 1. Nesting/Grouping of setCommits options
The new options: ` commit, previousCommit, repo, auto` feels a bit polluting in the sentry-webpack-plugin's "global" options scope in my opinion. The key annoying me the most is `auto`.
`auto` has no context when seen like this:
```js
const sentryCliPlugin = new SentryCliPlugin({
      release: '42',
      auto: true,
});
```
My suggestion is to group the setCommits/git options in a object:
```js
const sentryCliPlugin = new SentryCliPlugin({
      release: '42',
      setCommits: {
          auto: true,
          //Other setCommits options here...
      }
});
```
I modified the code in index.js to reflect this and tried to do the same in the tests. However, **the tests are not passing**. I have no experience with writing tests sadly, so I do not see what I can do to make them pass. Logging `this.options.setCommits` gives expecting result 🤷‍♂. Hopefully someone can help me out here if they think this PR is reasonable.


### 2. Readme changes
I do not know if there is a typo here or if I'm too tired to see that i'm wrong, but it seems to me that the key: `repo` :
https://github.com/getsentry/sentry-webpack-plugin/blob/5363d16d563709fe04291b218cfd80a629d637e1/README.md#L115

is indeed **not** optional:
https://github.com/getsentry/sentry-webpack-plugin/blob/5363d16d563709fe04291b218cfd80a629d637e1/src/index.js#L327

I don't know about the others, but I think we should do a deeper check to see what is required and what is not.

Yet again, awesome PR! I have been waiting for this for a long time ❤️ 