### PR TITLE
[Suggestion] - Move options to markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,55 +59,27 @@ Also, check the [example](example) directory.
 
 #### Options
 
-* `release [optional]` - unique name of a release, must be a `string`, should
-  uniquely identify your release, defaults to
-  `sentry-cli releases propose-version` command which should always return the
-  correct version (**requires access to `git` CLI and root directory to be a valid
-  repository**).
-* `include [required]` - `string` or `array`, one or more paths that Sentry CLI
-  should scan recursively for sources. It will upload all `.map` files and match
-  associated `.js` files
-* `entries [optional]` - `array` or `RegExp` or `function(key: string): bool`, a
-  filter for entry points that should be processed. By default, the release will
-  be injected into all entry points.
-* `ignoreFile [optional]` - `string`, path to a file containing list of
-  files/directories to ignore. Can point to `.gitignore` or anything with same
-  format
-* `ignore [optional]` - `string` or `array`, one or more paths to ignore during
-  upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or
-  `ignore` are present, defaults to `['node_modules']`
-* `configFile [optional]` - `string`, path to Sentry CLI config properties, as
-  described in https://docs.sentry.io/learn/cli/configuration/#properties-files.
-  By default, the config file is looked for upwards from the current path and
-  defaults from `~/.sentryclirc` are always loaded
-* `ext [optional]` - `array`, this sets the file extensions to be
-  considered. By default the following file extensions are processed: js, map,
-  jsbundle and bundle.
-* `urlPrefix [optional]` - `string`, this sets an URL prefix at the beginning
-  of all files. This defaults to `~/` but you might want to set this to the
-  full URL. This is also useful if your files are stored in a sub folder. eg:
-  `url-prefix '~/static/js'`
-* `urlSuffix [optional]` - `string`, this sets an URL suffix at the end of all
-  files. Useful for appending query parameters.
-* `validate [optional]` - `boolean`, this attempts sourcemap validation before
-  upload when rewriting is not enabled. It will spot a variety of issues with
-  source maps and cancel the upload if any are found. This is not the default as
-  this can cause false positives.
-* `stripPrefix [optional]` - `array`, when paired with `rewrite` this will
-  chop-off a prefix from uploaded files. For instance you can use this to remove
-  a path that is build machine specific.
-* `stripCommonPrefix [optional]` - `boolean`, when paired with `rewrite` this
-  will add `~` to the `stripPrefix` array.
-* `sourceMapReference [optional]` - `boolean`, this prevents the automatic
-  detection of sourcemap references.
-* `rewrite [optional]` - `boolean`, enables rewriting of matching sourcemaps so
-  that indexed maps are flattened and missing sources are inlined if possible.,
-  defaults to `true`
-* `dryRun [optional]` - `boolean`, attempts a dry run (useful for dev
-  environments)
-* `debug [optional]` - `boolean`, print some useful debug information
-* `silent [optional]` - `boolean`, if `true`, all logs are suppressed (useful for `--json` option)
-* `errorHandler [optional]` - `function(err: Error, invokeErr: function(): void): void`, when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr() }`
+Option | Type | Required | Description |
+-------|------|----------|-------------
+release | `string` | optional | unique name of a release, must be a `string`, should uniquely identify your release, defaults to `sentry-cli releases propose-version` command which should always return the correct version (**requires access to `git` CLI and root directory to be a valid repository**).
+include | `string`/`array` | required | one or more paths that Sentry CLI should scan recursively for sources. It will upload all `.map` files and match associated `.js` files |
+entries | `array`/`RegExp`/`function(key: string): bool` | optional | a filter for entry points that should be processed. By default, the release will be injected into all entry points. |
+| ignoreFile | `string` | optional | path to a file containing list of files/directories to ignore. Can point to `.gitignore` or anything with same format |
+| ignore | `string`/`array` | optional | one or more paths to ignore during upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or `ignore` are present, defaults to `['node_modules']` |
+| configFile | `string` | optional | path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files. By default, the config file is looked for upwards from the current path and defaults from `~/.sentryclirc` are always loaded |
+| ext | `array` | optional | this sets the file extensions to be considered. By default the following file extensions are processed: js, map, jsbundle and bundle. |
+| urlPrefix | `string` | optional | this sets an URL prefix at the beginning of all files. This defaults to `~/` but you might want to set this to the full URL. This is also useful if your files are stored in a sub folder. eg: `url-prefix '~/static/js'` |
+| urlSuffix | `string` | optional | this sets an URL suffix at the end of all files. Useful for appending query parameters. |
+| validate | `boolean` | optional | this attempts sourcemap validation before upload when rewriting is not enabled. It will spot a variety of issues with source maps and cancel the upload if any are found. This is not the default as this can cause false positives. |
+| stripPrefix | `array` | optional | when paired with `rewrite` this will chop-off a prefix from uploaded files. For instance you can use this to remove a path that is build machine specific. |
+| stripCommonPrefix | `boolean` | optional |  when paired with `rewrite` this will add `~` to the `stripPrefix` array. |
+| sourceMapReference | `boolean` | optional | this prevents the automatic detection of sourcemap references. |
+| rewrite | `boolean` | optional | enables rewriting of matching sourcemaps so that indexed maps are flattened and missing sources are inlined if possible. defaults to `true` |
+| dryRun | `boolean` | optional | attempts a dry run (useful for dev environments) |
+| debug | `boolean` | optional | print some useful debug information |
+| silent | `boolean` | optional | if `true`, all logs are suppressed (useful for `--json` option) |
+| errorHandler | `function(err: Error, invokeErr: function(): void): void` | optional | when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr()}` |
+
 
 set-commits options:
 * `commit [optional]` - `string`, the current (last) commit in the release


### PR DESCRIPTION
Created markdown table for the options to make it a bit easier to read.

I left the set-commits part out due to #142. I will add it when #142 is concluded. (Either nested or not)

A lot of manual copy-pasting here, so I would appreciate if another pair of 👀 control-checked it 🌮 

#### Options
<details>
<summary>Click me to preview table</summary>

Option | Type | Required | Description |
-------|------|----------|-------------
release | `string` | optional | unique name of a release, must be a `string`, should uniquely identify your release, defaults to `sentry-cli releases propose-version` command which should always return the correct version (**requires access to `git` CLI and root directory to be a valid repository**).
include | `string`/`array` | required | one or more paths that Sentry CLI should scan recursively for sources. It will upload all `.map` files and match associated `.js` files |
entries | `array`/`RegExp`/`function(key: string): bool` | optional | a filter for entry points that should be processed. By default, the release will be injected into all entry points. |
| ignoreFile | `string` | optional | path to a file containing list of files/directories to ignore. Can point to `.gitignore` or anything with same format |
| ignore | `string`/`array` | optional | one or more paths to ignore during upload. Overrides entries in `ignoreFile` file. If neither `ignoreFile` or `ignore` are present, defaults to `['node_modules']` |
| configFile | `string` | optional | path to Sentry CLI config properties, as described in https://docs.sentry.io/learn/cli/configuration/#properties-files. By default, the config file is looked for upwards from the current path and defaults from `~/.sentryclirc` are always loaded |
| ext | `array` | optional | this sets the file extensions to be considered. By default the following file extensions are processed: js, map, jsbundle and bundle. |
| urlPrefix | `string` | optional | this sets an URL prefix at the beginning of all files. This defaults to `~/` but you might want to set this to the full URL. This is also useful if your files are stored in a sub folder. eg: `url-prefix '~/static/js'` |
| urlSuffix | `string` | optional | this sets an URL suffix at the end of all files. Useful for appending query parameters. |
| validate | `boolean` | optional | this attempts sourcemap validation before upload when rewriting is not enabled. It will spot a variety of issues with source maps and cancel the upload if any are found. This is not the default as this can cause false positives. |
| stripPrefix | `array` | optional | when paired with `rewrite` this will chop-off a prefix from uploaded files. For instance you can use this to remove a path that is build machine specific. |
| stripCommonPrefix | `boolean` | optional |  when paired with `rewrite` this will add `~` to the `stripPrefix` array. |
| sourceMapReference | `boolean` | optional | this prevents the automatic detection of sourcemap references. |
| rewrite | `boolean` | optional | enables rewriting of matching sourcemaps so that indexed maps are flattened and missing sources are inlined if possible. defaults to `true` |
| dryRun | `boolean` | optional | attempts a dry run (useful for dev environments) |
| debug | `boolean` | optional | print some useful debug information |
| silent | `boolean` | optional | if `true`, all logs are suppressed (useful for `--json` option) |
| errorHandler | `function(err: Error, invokeErr: function(): void): void` | optional | when Cli error occurs, plugin calls this function. webpack compilation failure can be chosen by calling `invokeErr` callback or not. default `(err, invokeErr) => { invokeErr()}` |

</details>