### PR TITLE
Fix for commit requirement when release flag is set to auto

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -325,7 +325,7 @@ class SentryCliPlugin {
         const { commit, previousCommit, repo, auto } =
           this.options.setCommits || this.options;
 
-        if (repo && (commit || auto)) {
+        if (auto || (repo && commit)) {
           this.cli.releases.setCommits(release, {
             commit,
             previousCommit,


### PR DESCRIPTION
Currently, if you want this plugin to also attach commits, you need to specify both `auto: true` and `repo: 'whatever/repo'`.

When calling the cli with `--auto`, we don't need the repo name, and this PR fixes that.

Also see getsentry/sentry-cli#618