### PR TITLE
chore: Fix error typo

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -322,7 +322,7 @@ class SentryCliPlugin {
 
         if (!release) {
           throw new Error(
-            `Unabled to determine version. Make sure to include \`release\` option or use the environment that supports auto-detection https://docs.sentry.io/cli/releases/#creating-releases`
+            `Unable to determine version. Make sure to include \`release\` option or use the environment that supports auto-detection https://docs.sentry.io/cli/releases/#creating-releases`
           );
         }
 


### PR DESCRIPTION
This PR fixes a minor grammatical mistake in an error message.

`Unabled` ---> `Unable`