### PR TITLE
Fix npm install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A webpack plugin acting as an interface to
 Using npm:
 
 ```
-$ npm install @sentry/webpack-plugin --only=dev
+$ npm install @sentry/webpack-plugin --save-dev
 ```
 
 Using yarn:


### PR DESCRIPTION
[--save-dev is for when installing a brand new package](https://docs.npmjs.com/cli/install)
--only=dev is for when you are telling npm to only install the packages listed under devDependencies, but it still adds NEW packages to non-dev section