### PR TITLE
fix: Return an actual error for propagation

### DIFF
--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -138,7 +138,7 @@ describe('afterEmitHook', () => {
     setImmediate(() => {
       expect(compilationDoneCallback).toBeCalled();
       expect(compilation.errors).toEqual([
-        'Sentry CLI Plugin: `include` option is required',
+        new Error('Sentry CLI Plugin: `include` option is required'),
       ]);
       done();
     });
@@ -206,7 +206,9 @@ describe('afterEmitHook', () => {
     sentryCliPlugin.apply(compiler);
 
     setImmediate(() => {
-      expect(compilation.errors).toEqual(['Sentry CLI Plugin: Pickle Rick']);
+      expect(compilation.errors).toEqual([
+        new Error('Sentry CLI Plugin: Pickle Rick'),
+      ]);
       expect(compilationDoneCallback).toBeCalled();
       done();
     });

--- a/src/index.js
+++ b/src/index.js
@@ -370,13 +370,16 @@ class SentryCliPlugin {
         }
         return undefined;
       })
-      .catch(err =>
+      .catch(err => {
         errorHandler(
           err,
-          () => compilation.errors.push(`Sentry CLI Plugin: ${err.message}`),
+          () =>
+            compilation.errors.push(
+              new Error(`Sentry CLI Plugin: ${err.message}`)
+            ),
           compilation
-        )
-      );
+        );
+      });
   }
 
   /** Webpack lifecycle hook to update compiler options. */


### PR DESCRIPTION
Without this programs will generally suppress the errors. I believe this is because they expect it to be an error object and they're reporting on `obj.message`.