### PR TITLE
feat: Support minimal CLI options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,19 @@
 import { Plugin, Compiler } from 'webpack';
 
 export interface SentryCliPluginOptions {
+  // general configuration for sentry-cli
+
+  // Sentry instance
+  url?: string;
+  // Authentication token for API
+  authToken?: string;
+  // Organization slug
+  org?: string;
+  // Project slug
+  project?: string;
+  // VCS remote name
+  vcsRemote?: string;
+
   /**
    * Unique name of a release, must be a string, should uniquely identify your release,
    * defaults to sentry-cli releases propose-version command which should always return the correct version

--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,10 @@ class SentryCliPlugin {
   getSentryCli() {
     const cli = new SentryCli(this.options.configFile, {
       silent: this.isSilent(),
+      org: this.options.org,
+      project: this.options.project,
+      authToken: this.options.authToken,
+      url: this.options.url,
     });
 
     if (this.isDryRun()) {


### PR DESCRIPTION
This makes it possible to greatly simplify the user experience for customers trying to upload sourcemaps. We already install the sentry-cli via the npm package, but they were still required to setup a fairly cryptic configuration _in addition to_ also having to setup configuration in the plugin itself for various things. This ensures they can configure the entirety of the process within the webpack plugin.

Requires https://github.com/getsentry/sentry-cli/pull/830