### PR TITLE
Add support for webpack@5

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, Compiler } from 'webpack';
+import { WebpackPluginInstance, Compiler } from 'webpack';
 
 export interface SentryCliPluginOptions {
   // general configuration for sentry-cli
@@ -192,7 +192,7 @@ export interface SentryCliPluginOptions {
   };
 }
 
-declare class SentryCliPlugin extends Plugin {
+declare class SentryCliPlugin implements WebpackPluginInstance {
   constructor(options: SentryCliPluginOptions);
 
   apply(compiler: Compiler): void;


### PR DESCRIPTION
I have updated to webpack@5 then tsc failed to check.

> node_modules/@sentry/webpack-plugin/index.d.ts:1:10 - error TS2305: Module '"../../webpack/types"' has no exported member 'Plugin'.

so webpack@5 have [type definition file](https://github.com/webpack/webpack/blob/master/types.d.ts) and it doesn't export `Plugin` but it seems to use ` WebpackPluginInstance`. ref: https://github.com/webpack/webpack/issues/11630#issuecomment-706632671

I think it doesn't have compatibility webpack@4 so you should treat this change as a breaking change. 