### PR TITLE
fix Webpack 5 types issue #258

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, Compiler } from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack';
 
 export interface SentryCliPluginOptions {
   // general configuration for sentry-cli
@@ -192,7 +192,7 @@ export interface SentryCliPluginOptions {
   };
 }
 
-declare class SentryCliPlugin extends Plugin {
+declare class SentryCliPlugin implements WebpackPluginInstance {
   constructor(options: SentryCliPluginOptions);
 
   apply(compiler: Compiler): void;


### PR DESCRIPTION
```
interface WebpackPluginInstance extends Plugin {}
```
This interface `WebpackPluginInstance` was specifically created in Webpack 4 to fix such issues

// Compatibility with webpack@5's own types
// See https://github.com/webpack/webpack/issues/11630