### PR TITLE
feat: add `cleanAftifacts` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Also, check the [example](example) directory.
 | dryRun | `boolean` | optional | Attempts a dry run (useful for dev environments). Defaults to `false`. |
 | debug | `boolean` | optional | Print useful debug information. Defaults to `false`.|
 | silent | `boolean` | optional | Suppresses all logs (useful for `--json` option). Defaults to `false`. |
-| cleanArtifacts | `boolean` | optional | Before uploading the Artifacts, remove all the Artifacts in the release. Defaults to `false`. |
+| cleanArtifacts | `boolean` | optional | Remove all the artifacts in the release before the upload. Defaults to `false`. |
 | errorHandler | `function(err: Error, invokeErr: function(): void, compilation: Compilation): void` | optional | Function to call a when CLI error occurs. Webpack compilation failure can be triggered by calling `invokeErr` callback. Can emit a warning rather than an error (allowing compilation to continue) by setting this to `(err, invokeErr, compilation) => { compilation.warnings.push('Sentry CLI Plugin: ' + err.message) }`. Defaults to `(err, invokeErr) => { invokeErr() }`. |
 | setCommits | `Object` | optional | Adds commits to Sentry. See [table below](#setCommits) for details. |
 | deploy | `Object` | optional | Creates a new release deployment in Sentry. See [table below](#deploy) for details. |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Also, check the [example](example) directory.
 | dryRun | `boolean` | optional | Attempts a dry run (useful for dev environments). Defaults to `false`. |
 | debug | `boolean` | optional | Print useful debug information. Defaults to `false`.|
 | silent | `boolean` | optional | Suppresses all logs (useful for `--json` option). Defaults to `false`. |
+| cleanArtifacts | `boolean` | optional | Before uploading the Artifacts, remove all the Artifacts in the release. Defaults to `false`. |
 | errorHandler | `function(err: Error, invokeErr: function(): void, compilation: Compilation): void` | optional | Function to call a when CLI error occurs. Webpack compilation failure can be triggered by calling `invokeErr` callback. Can emit a warning rather than an error (allowing compilation to continue) by setting this to `(err, invokeErr, compilation) => { compilation.warnings.push('Sentry CLI Plugin: ' + err.message) }`. Defaults to `(err, invokeErr) => { invokeErr() }`. |
 | setCommits | `Object` | optional | Adds commits to Sentry. See [table below](#setCommits) for details. |
 | deploy | `Object` | optional | Creates a new release deployment in Sentry. See [table below](#deploy) for details. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,11 @@ export interface SentryCliPluginOptions {
   silent?: boolean;
 
   /**
+   * If true, before uploading the Artifacts, clean all the Artifacts in the release.
+   */
+  cleanArtifacts?: boolean;
+
+  /**
    * when Cli error occurs, plugin calls this function.
    * webpack compilation failure can be chosen by calling invokeErr callback or not.
    * defaults to `(err, invokeErr) => { invokeErr() }`

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ export interface SentryCliPluginOptions {
   silent?: boolean;
 
   /**
-   * If true, before uploading the Artifacts, clean all the Artifacts in the release.
+   * If true, will remove all previously uploaded artifacts from the configured release.
    */
   cleanArtifacts?: boolean;
 

--- a/src/index.js
+++ b/src/index.js
@@ -391,6 +391,15 @@ class SentryCliPlugin {
 
         return this.cli.releases.new(release);
       })
+      .then(() => {
+        if (this.options.cleanArtifacts) {
+          return this.cli.releases.execute(
+            ['releases', 'files', release, 'delete', '--all'],
+            true
+          );
+        }
+        return undefined;
+      })
       .then(() => this.cli.releases.uploadSourceMaps(release, this.options))
       .then(() => {
         const { commit, previousCommit, repo, auto } =


### PR DESCRIPTION
When an artifact has a hash （example: `[contenthash]` on webpack）, it will be generated for each build.
Currently, we need to run the `delete` command with sentry-cli to clean the artifacts.
This is a PR that adds an option to allow the plugin to clean.

There is no command in sentry-cli that supports clean, so I'm running the clean command with `execute`.
I'm sorry if this PR shouldn't be the role of this plugin.