### PR TITLE
feat: Add runOnce flag to allow for skipping multiple uploads with the same config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -106,6 +106,13 @@ export interface SentryCliPluginOptions {
   finalize?: boolean;
 
   /**
+   * Determines whether plugin should be applied not more than once during whole webpack run.
+   * Useful when the process is performing multiple builds using the same config.
+   * Defaults to `false`.
+   */
+  runOnce?: boolean;
+
+  /**
    * Attempts a dry run (useful for dev environments).
    */
   dryRun?: boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,6 @@ function attachAfterEmitHook(compiler, callback) {
 class SentryCliPlugin {
   constructor(options = {}) {
     const defaults = {
-      debug: false,
       finalize: true,
       rewrite: true,
     };
@@ -452,6 +451,21 @@ class SentryCliPlugin {
 
   /** Webpack lifecycle hook to update compiler options. */
   apply(compiler) {
+    /**
+     * Determines whether plugin should be applied not more than once during whole webpack run.
+     * Useful when the process is performing multiple builds using the same config.
+     * It cannot be stored on the instance, as every run is creating a new one.
+     */
+    if (this.options.runOnce && module.alreadyRun) {
+      if (this.options.debug) {
+        this.outputDebug(
+          '`runOnce` option set and plugin already ran. Skipping release.'
+        );
+      }
+      return;
+    }
+    module.alreadyRun = true;
+
     const compilerOptions = compiler.options || {};
     ensure(compilerOptions, 'module', Object);
 


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-webpack-plugin/issues/269

This is an issue when using custom Gatsby webpack config and someone won't specify a `stage` in which plugin should be applied https://www.gatsbyjs.com/docs/how-to/custom-configuration/add-custom-webpack-config/ or when bundling serverless functions as individual artifacts https://www.serverless.com/framework/docs/providers/aws/guide/packaging/