### PR TITLE
chore(dev): Add webpack types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@sentry/cli": "^1.64.1"
   },
   "devDependencies": {
+    "@types/webpack": "^4.39.3",
     "codecov": "^3.5.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",


### PR DESCRIPTION
Even though the webpack plugin itself isn't written in TS, it gets included in things which are (like `@sentry/nextjs`), and under certain conditions that means it would be helpful to have types here.