### PR TITLE
improved the code injected by sentry-loader to avoid collisions on micro frontend apps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -299,6 +299,8 @@ class SentryCliPlugin {
       loader: SENTRY_LOADER,
       options: {
         releasePromise: this.release,
+        org: this.options.org || process.env.SENTRY_ORG,
+        project: this.options.project || process.env.SENTRY_PROJECT,
       },
     };
 
@@ -314,6 +316,8 @@ class SentryCliPlugin {
           loader: SENTRY_LOADER,
           options: {
             releasePromise: this.release,
+            org: this.options.org || process.env.SENTRY_ORG,
+            project: this.options.project || process.env.SENTRY_PROJECT,
           },
         },
       ],

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,8 +1,12 @@
 module.exports = function sentryLoader(content, map, meta) {
-  const { releasePromise } = this.query;
+  const { releasePromise, org, project } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    const sentryRelease = `(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}).SENTRY_RELEASE={id:"${version}"};`;
+    let sentryRelease = `const _global = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}); _global.SENTRY_RELEASE={id:"${version}"};`;
+    if (project) {
+      const key = org ? `${project}@${org}` : project;
+      sentryRelease += `_global.SENTRY_RELEASES=_global.SENTRY_RELEASES||{}; _global.SENTRY_RELEASES["${key}"]={id:"${version}"};`;
+    }
     callback(null, sentryRelease, map, meta);
   });
 };


### PR DESCRIPTION
now, sentry-loader adds a new variable into global scope named SENTRY_RELEASES as an object that holds the versions of all applications that can be accessed by keys defined as "{project}@{org}"