### PR TITLE
Add Module Federation Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "dependencies": {
     "@sentry/cli": "^1.67.1"
   },
+  "peerDependencies": {
+    "webpack-sources": "*"
+  },
   "devDependencies": {
     "codecov": "^3.5.0",
     "eslint": "^5.16.0",
@@ -30,7 +33,8 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "prettier-check": "^2.0.0",
-    "webpack": "^4.39.3"
+    "webpack": "^4.39.3",
+    "webpack-sources": "^2.3.0"
   },
   "scripts": {
     "lint": "run-s lint:prettier lint:eslint",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,6 @@
   "dependencies": {
     "@sentry/cli": "^1.67.2"
   },
-  "peerDependencies": {
-    "webpack-sources": "*"
-  },
   "devDependencies": {
     "codecov": "^3.5.0",
     "eslint": "^5.16.0",
@@ -33,8 +30,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",
     "prettier-check": "^2.0.0",
-    "webpack": "^4.39.3",
-    "webpack-sources": "^2.3.0"
+    "webpack": "^4.39.3"
   },
   "scripts": {
     "lint": "run-s lint:prettier lint:eslint",

--- a/src/__tests__/index.spec.js
+++ b/src/__tests__/index.spec.js
@@ -167,6 +167,29 @@ describe('afterEmitHook', () => {
     });
   });
 
+  test('uses `output.path` from webpack config as default `include` path', done => {
+    compiler.options = {
+      output: {
+        path: './build',
+      },
+    };
+
+    const sentryCliPlugin = new SentryCliPlugin({
+      release: '42',
+    });
+    sentryCliPlugin.apply(compiler);
+
+    setImmediate(() => {
+      expect(mockCli.releases.uploadSourceMaps).toBeCalledWith(
+        '42',
+        expect.objectContaining({
+          include: ['./build'],
+        })
+      );
+      done();
+    });
+  });
+
   test('skips finalizing release if finalize:false', done => {
     expect.assertions(4);
 

--- a/src/index.js
+++ b/src/index.js
@@ -476,6 +476,12 @@ class SentryCliPlugin {
     }
 
     attachAfterEmitHook(compiler, (compilation, cb) => {
+      if (!this.options.include || !this.options.include.length) {
+        ensure(compilerOptions, 'output', Object);
+        if (compilerOptions.output.path) {
+          this.options.include = [compilerOptions.output.path];
+        }
+      }
       this.finalizeRelease(compilation).then(() => cb());
     });
   }

--- a/src/index.js
+++ b/src/index.js
@@ -86,7 +86,7 @@ function attachAfterCodeGenerationHook(compiler, options) {
       compilation.hooks.afterCodeGeneration.tap('SentryCliPlugin', () => {
         compilation.modules.forEach(module => {
           // eslint-disable-next-line no-underscore-dangle
-          if (module._name !== options.remoteModuleName) return;
+          if (module._name !== moduleFederationPlugin._options.name) return;
           const sourceMap = compilation.codeGenerationResults.get(module)
             .sources;
           const rawSource = sourceMap.get('javascript');

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 const SentryCli = require('@sentry/cli');
 const path = require('path');
 const util = require('util');
-const { RawSource } = require('webpack-sources');
 
 const SENTRY_LOADER = path.resolve(__dirname, 'sentry.loader.js');
 const SENTRY_MODULE = path.resolve(__dirname, 'sentry-webpack.module.js');
@@ -84,6 +83,8 @@ function attachAfterCodeGenerationHook(compiler, options) {
   if (!moduleFederationPlugin) {
     return;
   }
+
+  const { RawSource } = require('webpack-sources');
 
   compiler.hooks.make.tapAsync('SentryCliPlugin', (compilation, cb) => {
     options.releasePromise.then(version => {

--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,11 @@ function attachAfterEmitHook(compiler, callback) {
 }
 
 function attachAfterCodeGenerationHook(compiler, options) {
+  if (!compiler.hooks || !compiler.hooks.make) {
+    return;
+  }
   const moduleFederationPlugin =
+    compiler.options &&
     compiler.options.plugins &&
     compiler.options.plugins.find(
       x => x.constructor.name === 'ModuleFederationPlugin'

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,8 +1,15 @@
 module.exports = function sentryLoader(content, map, meta) {
-  const { releasePromise } = this.query;
+  const { releasePromise, org, project } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    const sentryRelease = `(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}).SENTRY_RELEASE={id:"${version}"};`;
+    let sentryRelease = `const _global = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}); _global.SENTRY_RELEASE={id:"${version}"};`;
+    if (project) {
+      const key = org ? `${project}@${org}` : project;
+      sentryRelease += `
+      _global.SENTRY_RELEASES=_global.SENTRY_RELEASES||{};
+      _global.SENTRY_RELEASES["${key}"]={id:"${version}"};
+      `;
+    }
     callback(null, sentryRelease, map, meta);
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4785,7 +4785,7 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -5457,6 +5457,14 @@ webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.3.0.tgz#9ed2de69b25143a4c18847586ad9eccb19278cfa"
+  integrity sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@^4.39.3:
   version "4.46.0"


### PR DESCRIPTION
TL;DR;

the plugin now injects additional SENTRY_RELEASES variable into global scope as an object that holds versions for all apps keyed by [project]@[org]

-----
When ModuleFederationPlugin is used, assuming the project has a single entry in the webpack config, the build outputs a bundle with two separate entrypoints; usually named as 'main' and 'remoteEntry'. Main is used when the app is running in standalone (host) mode and remoteEntry is used when it is consumed as a remote by another app. In our projects we needed to access the version value for all remotes on our host app so that we can create SentryClient per remote with their own respective versions.

With this PR, the code injected by loader is improved to include a second variable `SENTRY_RELEASES` in addition to `SENTRY_RELEASE`. This code goes to main module and is not loaded when the app is running as remote. So I also added the part to tap into compilation and inject the variable in remoteEntry as well.

If this is accepted, we can maybe open another PR on @sentry/browser so that the default release is read from SENTRY_RELEASES and retire SENTRY_RELEASE
