### PR TITLE
fix(types): Add missing `SentryCliUploadSourceMapsOptions` import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ import {
   SentryCliCommitsOptions,
   SentryCliNewDeployOptions,
   SentryCliOptions,
+  SentryCliUploadSourceMapsOptions,
 } from '@sentry/cli';
 
 export interface SentryCliPluginOptions


### PR DESCRIPTION
We've been using `SentryCliUploadSourceMapsOptions`, but without actually having imported it. This fixes that.