### PR TITLE
chore(deps): Update @sentry/cli to 1.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@sentry/cli": "^1.67.2"
+    "@sentry/cli": "^1.68.0"
   },
   "devDependencies": {
     "codecov": "^3.5.0",


### PR DESCRIPTION
This bumps our `@sentry/cli` dependency in order to take advantage of https://github.com/getsentry/sentry-cli/pull/1001. Once this change is released, it will unblock https://github.com/getsentry/sentry-javascript/pull/3845.