### PR TITLE
ci(release): Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,25 @@
-name: Prepare Release
+name: Release
 on:
   workflow_dispatch:
     inputs:
       version:
         description: Version to release
-        required: true
+        required: false
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
-
 jobs:
   release:
     runs-on: ubuntu-latest
     name: 'Release a new version'
     steps:
-      - name: Prepare release
-        uses: getsentry/action-prepare-release@main
-        with:
-          version: ${{ github.event.inputs.version }}
-          force: ${{ github.event.inputs.force }}
       - uses: actions/checkout@v2
         with:
           token: ${{ secrets.GH_RELEASE_PAT }}
-          fetch-depth: 0
-      - name: Craft Prepare
-        run: npx @sentry/craft prepare --no-input "${{ env.RELEASE_VERSION }}"
+      - name: Prepare release
+        uses: getsentry/action-prepare-release@v1
         env:
-          GITHUB_API_TOKEN: ${{ github.token }}
-      - name: Request publish
-        if: success()
-        uses: actions/github-script@v3
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         with:
-          github-token: ${{ secrets.GH_RELEASE_PAT }}
-          script: |
-            const repoInfo = context.repo;
-            await github.issues.create({
-              owner: repoInfo.owner,
-              repo: 'publish',
-              title: `publish: ${repoInfo.repo}@${process.env.RELEASE_VERSION}`,
-            });
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}


### PR DESCRIPTION
The release workflow here was relying on a very old version of `getsentry/action-prepare-release` but was referring to its `@main` branch and breaking due to major changes.

This PR brings the workflow up to speed with the recent version of it.