### PR TITLE
add support for multiple apps using module federation

### DIFF
--- a/example/test.js
+++ b/example/test.js
@@ -42,7 +42,6 @@ _global.SENTRY_RELEASES["my-project@my-org"] = {
   ) !== -1
 ) {
   console.log('Saul Goodman, found SENTRY_RELEASES assignment in bundle');
-  process.exit(0);
 } else {
   console.error('Boom, did not find SENTRY_RELEASES assignment in bundle');
   process.exit(1);

--- a/example/test.js
+++ b/example/test.js
@@ -8,14 +8,42 @@ console.log();
 
 const content = fs.readFileSync('./dist/main.bundle.js');
 if (
-  content.toString()
-    .indexOf(`(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}).SENTRY_RELEASE = {
+  content
+    .toString()
+    .indexOf(
+      `var _global = typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};`
+    ) !== -1
+) {
+  console.log('Saul Goodman, found "var _global" assignment in bundle');
+} else {
+  console.error('Boom, did not find "var _global" assignment in bundle');
+  process.exit(1);
+}
+
+if (
+  content.toString().indexOf(
+    `_global.SENTRY_RELEASE = {
   id: "foo"
-}`) !== -1
+};`
+  ) !== -1
 ) {
   console.log('Saul Goodman, found SENTRY_RELEASE in bundle');
-  process.exit(0);
 } else {
   console.error('Boom, did not find SENTRY_RELEASE in bundle');
+  process.exit(1);
+}
+
+if (
+  content.toString().indexOf(
+    `_global.SENTRY_RELEASES = _global.SENTRY_RELEASES || {};
+_global.SENTRY_RELEASES["my-project@my-org"] = {
+  id: "foo"
+};`
+  ) !== -1
+) {
+  console.log('Saul Goodman, found SENTRY_RELEASES assignment in bundle');
+  process.exit(0);
+} else {
+  console.error('Boom, did not find SENTRY_RELEASES assignment in bundle');
   process.exit(1);
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -29,6 +29,8 @@ module.exports = {
       configFile: 'sentry.properties',
       dryRun: true,
       release: 'foo',
+      project: 'my-project',
+      org: 'my-org',
       dist: '123',
     }),
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -83,9 +83,12 @@ function attachAfterCodeGenerationHook(compiler, options) {
   try {
     // eslint-disable-next-line global-require, import/no-extraneous-dependencies
     webpackSources = require('webpack-sources');
-  } catch(_e) {}
-
-  if (!webpackSources) return;
+  } catch (_e) {
+    console.warn(
+      'Coud not resolve package: webpack-sources. Skipping injection for the remote entry file.'
+    );
+    return;
+  }
 
   const { RawSource } = webpackSources;
   const moduleFederationPlugin =
@@ -104,7 +107,7 @@ function attachAfterCodeGenerationHook(compiler, options) {
       compilation.hooks.afterCodeGeneration.tap('SentryCliPlugin', () => {
         compilation.modules.forEach(module => {
           // eslint-disable-next-line no-underscore-dangle
-          if (module._name !== options.remoteModuleName) return;
+          if (module._name !== moduleFederationPlugin._options.name) return;
           const sourceMap = compilation.codeGenerationResults.get(module)
             .sources;
           const rawSource = sourceMap.get('javascript');

--- a/src/index.js
+++ b/src/index.js
@@ -79,9 +79,11 @@ function attachAfterCodeGenerationHook(compiler, options) {
     return;
   }
 
-  // eslint-disable-next-line global-require
-  const webpackSources = require(// eslint-disable-next-line import/no-extraneous-dependencies
-  'webpack-sources');
+  let webpackSources;
+  try {
+    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+    webpackSources = require('webpack-sources');
+  } catch(_e) {}
 
   if (!webpackSources) return;
 

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -1,8 +1,15 @@
 module.exports = function sentryLoader(content, map, meta) {
-  const { releasePromise } = this.query;
+  const { releasePromise, org, project } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    const sentryRelease = `(typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}).SENTRY_RELEASE={id:"${version}"};`;
+    let sentryRelease = `const _global = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}); _global.SENTRY_RELEASE={id:"${version}"};`;
+    if (project) {
+      const key = org ? `${project}@${org}` : project;
+      sentryRelease += `
+      _global.SENTRY_RELEASES=_global.SENTRY_RELEASES||{};
+      _global.SENTRY_RELEASES["${key}"]={id:"${version}"};
+      `;
+    }
     callback(null, sentryRelease, map, meta);
   });
 };

--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -6,7 +6,7 @@ module.exports = function sentryLoader(content, map, meta) {
     if (project) {
       const key = org ? `${project}@${org}` : project;
       sentryRelease += `
-      _global.SENTRY_RELEASES=_global.SENTRY_RELEASES||{};
+      _global.SENTRY_RELEASES=_global.SENTRY_RELEASES || {};
       _global.SENTRY_RELEASES["${key}"]={id:"${version}"};
       `;
     }


### PR DESCRIPTION
this is a recreated/clean version of https://github.com/getsentry/sentry-webpack-plugin/pull/291

I had to disable a few es-lint rules;
- index.js line 82-83: adding webpack-sources as dependency breaks the tests (some of the tests use older version(s) of node than webpack-sources requires as minimum). On the other hand, if the user is using module federation, their webpack version is at least 5 and webpack-sources come with it. So, adding webpack-sources as a dependency is not a must. For the same reason, I did not put the require statement at the top of the file (it might be missing for users using an older version of webpack)

- index js line 105; it is what it is, the rule says no-underscore-dangle but the object coming from webpack has it 🤷🏼‍♂️

----

TL;DR;

the plugin now injects additional SENTRY_RELEASES variable into global scope as an object that holds versions for all apps keyed by [project]@[org]

-----
When ModuleFederationPlugin is used, assuming the project has a single entry in the webpack config, the build outputs a bundle with two separate entrypoints; usually named as 'main' and 'remoteEntry'. Main is used when the app is running in standalone (host) mode and remoteEntry is used when it is consumed as a remote by another app. In our projects we needed to access the version value for all remotes on our host app so that we can create SentryClient per remote with their own respective versions.

With this PR, the code injected by loader is improved to include a second variable `SENTRY_RELEASES` in addition to `SENTRY_RELEASE`. This code goes to main module and is not loaded when the app is running as remote. So I also added the part to tap into compilation and inject the variable in remoteEntry as well.

If this is accepted, we can maybe open another PR on @sentry/browser so that the default release is read from SENTRY_RELEASES and retire SENTRY_RELEASE
