### PR TITLE
fix(types): Add `options` to main plugin type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,6 +103,7 @@ export interface SentryCliPluginOptions
 }
 
 declare class SentryCliPlugin implements WebpackPluginInstance {
+  options: SentryCliPluginOptions;
   constructor(options: SentryCliPluginOptions);
   apply(compiler: Compiler): void;
 }


### PR DESCRIPTION
The `SentryCliPlugin` class has a public property called `options`, but it's not in the type, so TS gets mad when you try to access it.