### PR TITLE
fix(ci): Increase stack size in errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - master
       - release/**
 
+env:
+  NODE_OPTIONS: '--stack-trace-limit=10000'
+
 jobs:
   build:
     name: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - release/**
   pull_request:
 
+env:
+  NODE_OPTIONS: '--stack-trace-limit=10000'
+
 jobs:
   lint:
     name: lint and codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,10 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+
+env:
+  NODE_OPTIONS: '--stack-trace-limit=10000'
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
By default, node limits stacktraces to 10 lines. That's often not enough to tell what's gone wrong, especially when dealing with async code (which can add many frames just handling its own asynciness). For example, when trying to release this plugin, I ran into this:

![image](https://user-images.githubusercontent.com/14812505/135669609-911f0733-4240-45e2-862a-00986a464cf0.png)

What's wrong? How do I fix it? No way to know.

Fortunately, node allows you to increase that limit, and since version 8, has further allowed you to specify global options via the `NODE_OPTIONS` environment variable. This PR does both, for all ci processes where we own the code that's being run.

Before:

![image](https://user-images.githubusercontent.com/14812505/135670776-21390e2b-2159-4246-877d-88e6c7213830.png)

After: 

![image](https://user-images.githubusercontent.com/14812505/135670560-aa404514-6999-48c0-bb83-30b2bf5221cb.png)
