### PR TITLE
chore(types): Reexport `SourceMapsPathDescriptor`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,6 +122,8 @@ declare namespace SentryCliPlugin {
      */
     deploy?: SentryCliNewDeployOptions;
   }
+
+  export { SourceMapsPathDescriptor };
 }
 
 declare class SentryCliPlugin implements WebpackPluginInstance {


### PR DESCRIPTION
This plugin has `@sentry/cli` as a dependency, and therefore anyone who has it installed will also have `@sentry/cli` installed. That said, if one tries to import directly from `@sentry/cli`, the linter complains unless you add it to your dependencies. This reexports a type from `@sentry/cli` to prevent that linter error (without forcing people to explicitly add `@sentry/cli` to their `package.json`).