### PR TITLE
ref: Use var instead of const for module loader for ES5-compat

### DIFF
--- a/src/sentry.loader.js
+++ b/src/sentry.loader.js
@@ -2,7 +2,7 @@ module.exports = function sentryLoader(content, map, meta) {
   const { releasePromise, org, project } = this.query;
   const callback = this.async();
   releasePromise.then(version => {
-    let sentryRelease = `const _global = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}); _global.SENTRY_RELEASE={id:"${version}"};`;
+    let sentryRelease = `var _global = (typeof window !== 'undefined' ? window : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {}); _global.SENTRY_RELEASE={id:"${version}"};`;
     if (project) {
       const key = org ? `${project}@${org}` : project;
       sentryRelease += `


### PR DESCRIPTION
This PR changes the usage of `const` to `var` to preserve pre-ES6 compatibility.
If we use ES6 syntax, it requires end-user to always transpile it, as we inject directly into the bundle.

Ref: https://github.com/getsentry/sentry-webpack-plugin/pull/307#issuecomment-1002985337