### PR TITLE
deps: add missing peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
   "dependencies": {
     "@sentry/cli": "^1.72.0"
   },
+  "peerDependencies": {
+    "webpack": "^4.41.31 || ^5.0.0"
+  },
   "devDependencies": {
     "@types/webpack": "^4.41.31 || ^5.0.0",
     "codecov": "^3.5.0",


### PR DESCRIPTION
add webpack as peerDependency as webpack is used in index.d.ts for typing
https://github.com/getsentry/sentry-webpack-plugin/blob/4e85f797a4b9736c7d52e99c30c5dd933f3b4c3e/index.d.ts#L1