### PR TITLE
ci: Change changelogPolicy to auto for Craft releases

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,7 +1,7 @@
 github:
   owner: getsentry
   repo: sentry-webpack-plugin
-changelogPolicy: simple
+changelogPolicy: auto
 preReleaseCommand: bash scripts/craft-pre-release.sh
 statusProvider:
   name: github


### PR DESCRIPTION
So that I can maintain commits list as our changelog and make releases without redundant "added changelog" PRs.
https://github.com/getsentry/craft#changelog-policies