### PR TITLE
deps: Remove webpack from peerDep and move info about ver to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A webpack plugin acting as an interface to
 
 ### Installation
 
+`@sentry/webpack-plugin` requires at least `webpack@4.41.31` or any `webpack@5` version to be installed.
+
 Using npm:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -20,14 +20,6 @@
   "dependencies": {
     "@sentry/cli": "^1.72.0"
   },
-  "peerDependencies": {
-    "webpack": "^4.41.31 || ^5.0.0"
-  },
-  "peerDependenciesMeta": {
-    "webpack": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/webpack": "^4.41.31 || ^5.0.0",
     "codecov": "^3.5.0",


### PR DESCRIPTION
After discussing it with the team, we decided to revert this change, as the behavior of `peerDependenciesMeta` is not consistent across npm/yarn versions.

ref: https://github.com/getsentry/sentry-webpack-plugin/pull/343
ref: https://github.com/getsentry/sentry-webpack-plugin/pull/350