### PR TITLE
fix: replace git.io links with redirect targets

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -53,7 +53,7 @@ jobs:
         uses: github/codeql-action/autobuild@v1
 
       # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
+      # 📚 https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
       # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
       #    and modify them (or add more) to build your code if your project


### PR DESCRIPTION
see: https://github.blog/changelog/2022-04-25-git-io-deprecation/

Committed via https://github.com/asottile/all-repos