### PR TITLE
Add support for @sentry/cli v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@sentry/cli": "^1.74.4"
+    "@sentry/cli": "^1.74.4 || ^2.0.0"
   },
   "devDependencies": {
     "@types/webpack": "^4.41.31 || ^5.0.0",


### PR DESCRIPTION
Based on https://github.com/getsentry/sentry-webpack-plugin/issues/362, it looks like this package supports the new major v2 release of @sentry/cli. However, it's still configured to only support v1 in the package.json. This is causing multiple versions of @sentry/cli to be installed in my project. This is a quick fix to allow the v2 version to satisfy the dependency and ensure that projects on the most up to date version don't install multiple versions.

Please let me know if there is anything else you need me to do here to get this merged!