### PR TITLE
fix(deps): Add `webpack-sources` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@sentry/cli": "^1.74.4"
+    "@sentry/cli": "^1.74.4",
+    "webpack-sources": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@types/webpack": "^4.41.31 || ^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 const SentryCli = require('@sentry/cli');
 const path = require('path');
 const util = require('util');
+const { RawSource } = require('webpack-sources');
 
 const SENTRY_LOADER = path.resolve(__dirname, 'sentry.loader.js');
 const SENTRY_MODULE = path.resolve(__dirname, 'sentry-webpack.module.js');
@@ -75,23 +76,11 @@ function attachAfterEmitHook(compiler, callback) {
 }
 
 function attachAfterCodeGenerationHook(compiler, options) {
+  // This is only a problem for folks on webpack 3 and below
   if (!compiler.hooks || !compiler.hooks.make) {
     return;
   }
 
-  let webpackSources;
-  try {
-    // eslint-disable-next-line global-require, import/no-extraneous-dependencies
-    webpackSources = require('webpack-sources');
-  } catch (_e) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'Coud not resolve package: webpack-sources. Skipping injection for the remote entry file.'
-    );
-    return;
-  }
-
-  const { RawSource } = webpackSources;
   const moduleFederationPlugin =
     compiler.options &&
     compiler.options.plugins &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -4616,6 +4616,11 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+"webpack-sources@^2.0.0 || ^3.0.0":
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
+
 webpack-sources@^3.2.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.1.tgz#251a7d9720d75ada1469ca07dbb62f3641a05b6d"


### PR DESCRIPTION
In https://github.com/getsentry/sentry-webpack-plugin/pull/307, a dependency on `webpack-sources` was added to the code, but not to `package.json`. From that PR description:

> Adding webpack-sources as dependency breaks the tests (some of the tests use older version(s) of node than webpack-sources requires as minimum). On the other hand, if the user is using module federation, their webpack version is at least 5 and webpack-sources come with it. So, adding webpack-sources as a dependency is not a must. For the same reason, I did not put the require statement at the top of the file (it might be missing for users using an older version of webpack)

Though this logic is generally sound, it (specifically the "their webpack version is at least 5 and webpack-sources come with it" part) doesn't account for cases in which webpack is being consumed from a single bundle. In those cases, the _code_ from `webpack-sources` exists in the user's dev environment, but the actual `webpack-sources` _package_ doesn't. (This is true, for example, in nextjs, which pre-compiles many of its dependencies, [including webpack](https://github.com/vercel/next.js/blob/c2f48ea86d448c8be1982b46f184b1d2f2d6cd50/packages/next/compiled/webpack/bundle5.js), into minified bundles.) This can lead to errors when trying to use module federation alongside our nextjs SDK.

To fix this, `webpack-sources` has been added as a first-class runtime dependency. Because that guarantees that it will be present and `require`-able, its import has been moved out of a mid-file `try-catch` to instead be a legit import at the top of the file in which it's used.
