### PR TITLE
feat(test): Add debug profile for integration test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+
+    {
+      "name": "Debug integration test build",
+      "type": "node",
+      "cwd": "${workspaceFolder}/example",
+      "request": "launch",
+      "preLaunchTask": "Install Integration Test Dependencies",
+      "runtimeExecutable": "${workspaceFolder}/example/node_modules/.bin/webpack",
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart"
+    },
+    {
+      "name": "Debug integration test script",
+      "type": "node",
+      "cwd": "${workspaceFolder}/example",
+      "request": "launch",
+      "preLaunchTask": "Build Integration Test Example App",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["test.js"],
+      "skipFiles": [
+        "<node_internals>/**"
+      ],
+      "outputCapture": "std",
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Set up local @sentry/webpack-plugin for linking",
+			"type": "shell",
+			"command": "yarn link > /dev/null 2>&1",
+			"options": {"cwd": "${workspaceFolder}"},
+		},
+		{
+			"label": "Install Integration Test Dependencies",
+			"type": "shell",
+			"command": "yarn && yarn link @sentry/webpack-plugin",
+			"options": {"cwd": "${workspaceFolder}/example"},
+			"dependsOn": "Set up local @sentry/webpack-plugin for linking"
+		},
+		{
+			"label": "Build Integration Test Example App",
+			"type": "shell",
+			"command": "yarn webpack",
+			"options": {"cwd": "${workspaceFolder}/example"},
+			"dependsOn": "Install Integration Test Dependencies"
+		}
+	]
+}


### PR DESCRIPTION
This adds a VSCode debug profile for the integration test, both the build phase and the test phase.