### PR TITLE
chore(git): Add `.DS_Store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage
 dist
 yarn-error.log
 package-lock.json
+.DS_Store


### PR DESCRIPTION
Not sure why this hasn't come up long since, but our `.gitignore` is missing `.DS_Store`. This adds it.