### PR TITLE
feat: Add a means to detect if the CLI binary exists

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -130,6 +130,7 @@ declare namespace SentryCliPlugin {
 declare class SentryCliPlugin implements WebpackPluginInstance {
   options: SentryCliPlugin.SentryCliPluginOptions;
   constructor(options: SentryCliPlugin.SentryCliPluginOptions);
+  static cliBinaryExists(): string;
   apply(compiler: Compiler): void;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 const SentryCli = require('@sentry/cli');
+const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const { RawSource } = require('webpack-sources');
@@ -191,6 +192,10 @@ class SentryCliPlugin {
   /** Returns whether this plugin is in dryRun mode. */
   isDryRun() {
     return this.options.dryRun === true;
+  }
+
+  static cliBinaryExists() {
+    return fs.existsSync(SentryCli.getPath());
   }
 
   /** Creates a new Sentry CLI instance. */


### PR DESCRIPTION
It would be great if downstream consumers of the webpack plugin could check if the binary has successfully downloaded

Ref: https://github.com/getsentry/sentry-javascript/pull/6015