### PR TITLE
ci: Update actions/upload-artifact to v3.1.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - run: yarn install
       - run: yarn pack
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.1
         with:
           name: ${{ github.sha }}
           path: |


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos