### PR TITLE
fix: Update Webpack plugin to 1.75.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@sentry/cli": "^1.75.0",
+    "@sentry/cli": "^1.75.1",
     "webpack-sources": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@sentry/cli@^1.75.0":
-  version "1.75.0"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.75.0.tgz#4a5e71b5619cd4e9e6238cc77857c66f6b38d86a"
-  integrity sha512-vT8NurHy00GcN8dNqur4CMIYvFH3PaKdkX3qllVvi4syybKqjwoz+aWRCvprbYv0knweneFkLt1SmBWqazUMfA==
+"@sentry/cli@^1.75.1":
+  version "1.75.1"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.75.1.tgz#49fd43a0619de1c1fa802522a741c42171bf6d2a"
+  integrity sha512-LjVmzeiyJyHQH/0ZKeaYwHSrUcgh+FV1fYlkf+fSSRQiuvijB7vln0CisbxJnMgp4k8qoQ/ZSmTcfv6FGMKIEA==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"


### PR DESCRIPTION
This PR bumps the CLI to `1.75.1` to include a fix for source maps processing which caused certain webpack-built stackframes to be wrongly classified as `in-app: false`. This was expecially noticeable in Angular applications.