### PR TITLE
deps: Bump Sentry CLI to version to `^1.76.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">= 8"
   },
   "dependencies": {
-    "@sentry/cli": "^1.75.1",
+    "@sentry/cli": "^1.76.0",
     "webpack-sources": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,10 +361,10 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@sentry/cli@^1.75.1":
-  version "1.75.1"
-  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.75.1.tgz#49fd43a0619de1c1fa802522a741c42171bf6d2a"
-  integrity sha512-LjVmzeiyJyHQH/0ZKeaYwHSrUcgh+FV1fYlkf+fSSRQiuvijB7vln0CisbxJnMgp4k8qoQ/ZSmTcfv6FGMKIEA==
+"@sentry/cli@^1.76.0":
+  version "1.76.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-1.76.0.tgz#3d48248a4fec2fee7c4d30320c563c91c75290ec"
+  integrity sha512-56bVyUJoi52dop/rFEaSoU4AfVRXpR6M+nZBwN1iGUAwdfBrarNbtmIOjfgPi+tVzVB5ck09PzVXG6zeBqJJcA==
   dependencies:
     https-proxy-agent "^5.0.0"
     mkdirp "^0.5.5"


### PR DESCRIPTION
Bumps Sentry CLI to a version that supports org auth tokens.